### PR TITLE
ci: Fix broken source-build job by replacing Buffalo with go build (Echo)

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -39,15 +39,12 @@ jobs:
         with:
           go-version: ${{matrix.go-version}}
 
-      - name: Install Buffalo CLI
-        run: go install github.com/gobuffalo/cli/cmd/buffalo@v0.18.14
-
       - name: Install Go dependencies
         run: go mod download
         working-directory: ./api
-    
-      - name: Build Buffalo application
-        run: buffalo build --static
+
+      - name: Build API server (Echo)
+        run: go build -ldflags="-s -w" -o butterfly-api ./cmd/app
         working-directory: ./api
 
   # The job key is "build-container-image"


### PR DESCRIPTION
API 서버가 Buffalo → Echo v4 로 마이그레이션(#59)된 이후에도 GitHub Actions CI 의 'Build source code for butterfly api' 잡이 여전히 buffalo CLI 설치와 'buffalo build --static' 을 실행하고 있어, Buffalo 프로젝트 마커가 사라진 develop 브랜치 빌드 시 'you need to be inside your buffalo project path' 에러로 항상 실패하는 문제가 있었음.

- Install Buffalo CLI 단계 제거
- 'buffalo build --static' → 'go build -ldflags="-s -w" -o butterfly-api ./cmd/app' (api/Dockerfile 의 빌드 명령과 동일한 기준 적용)

검증: api/ 디렉토리에서 go 1.23+ 으로 위 명령 실행 시 정상적으로
butterfly-api 바이너리가 생성됨을 로컬에서 확인.