### PR TITLE
fix(workflow): support cm-cicada Type/Spec task schema and new task types in Workflow Tool

### DIFF
--- a/front/src/entities/workflow/lib/schemaAdapter.ts
+++ b/front/src/entities/workflow/lib/schemaAdapter.ts
@@ -1,0 +1,176 @@
+/**
+ * Backend schema adapter (cm-cicada Type/Spec migration).
+ *
+ * cm-cicada refactored task components and workflow tasks to a Type/Spec schema:
+ *   task_component: { id, name, description, type, spec, is_example, ... }
+ *   workflow task:  { name, task_component, spec, dependencies }
+ *
+ * where `type` is one of http | http_xcom | bash | ssh | trigger_workflow and
+ * `spec` is a type-specific map (see cm-cicada conf/task_types.yaml).
+ *
+ * The existing designer/editor code is built around the previous
+ * "data.options + path_params/query_params/body_params" shape. The helpers here
+ * translate between the two so the designer keeps working for http tasks and the
+ * new task types are supported by dedicated editors.
+ */
+
+export type TaskType =
+  | 'http'
+  | 'http_xcom'
+  | 'bash'
+  | 'ssh'
+  | 'trigger_workflow';
+
+/** Non-http task types that need dedicated editors. */
+export const CUSTOM_EDITOR_TASK_TYPES: TaskType[] = [
+  'http_xcom',
+  'bash',
+  'ssh',
+  'trigger_workflow',
+];
+
+/**
+ * Build the default legacy `options.request_body` string (parsed later into
+ * step.properties.model) for a component of the given type.
+ */
+function defaultComponentModelString(type: string, spec: any): string {
+  switch (type) {
+    case 'bash':
+      return JSON.stringify({ bash_command: spec.bash_command ?? '' });
+    case 'ssh':
+      return JSON.stringify({ command: spec.command ?? '' });
+    case 'trigger_workflow':
+      return JSON.stringify({ conf: spec.conf ?? {} });
+    case 'http_xcom':
+      return JSON.stringify({
+        request_body: spec.request_body ?? '',
+        response_path: spec.response_path ?? '',
+      });
+    case 'http':
+    default:
+      return spec.request_body && spec.request_body !== ''
+        ? spec.request_body
+        : '{}';
+  }
+}
+
+/**
+ * Convert a raw cm-cicada task component into the legacy shape the designer
+ * consumes. Mutates in place and is idempotent (already-legacy objects are left
+ * untouched). Keeps `type` and `spec` on the object for the per-type editors.
+ */
+export function normalizeTaskComponentInPlace(tc: any): any {
+  if (!tc || (tc.data && tc.data.options)) return tc; // already legacy shape
+  const spec = tc.spec ?? {};
+  const type: string = tc.type ?? 'http';
+
+  tc.type = type;
+  tc.spec = spec;
+  tc.data = {
+    options: {
+      api_connection_id: spec.api_connection_id ?? '',
+      endpoint: spec.endpoint ?? '',
+      method: spec.method ?? '',
+      request_body: defaultComponentModelString(type, spec),
+      path_params: {},
+    },
+    body_params: spec.body_params_schema ?? undefined,
+    path_params: { properties: spec.path_params_schema ?? null },
+    query_params: { properties: spec.query_params_schema ?? null },
+  };
+  return tc;
+}
+
+/** Normalize a task component list in place (idempotent). */
+export function normalizeTaskComponentList<T = any>(list: T[]): T[] {
+  if (Array.isArray(list)) list.forEach(normalizeTaskComponentInPlace);
+  return list;
+}
+
+/**
+ * Ensure a workflow/template task carries the legacy fields the http flow reads
+ * (`request_body`, `path_params`, `query_params`) and a resolved `type`, derived
+ * from its `spec`. Mutates in place, idempotent.
+ */
+export function normalizeWorkflowTaskInPlace(
+  task: any,
+  taskComponentList: any[],
+): any {
+  if (!task) return task;
+  // Idempotent: skip if already normalized (type resolved + legacy fields present).
+  if (task.type !== undefined && task.request_body !== undefined) return task;
+  const component = (taskComponentList || []).find(
+    c => c.name === task.task_component,
+  );
+  // `spec` may be absent for tasks with no task-level overrides (e.g. a GET http
+  // task, or a task whose fields live only on the component). Treat as empty.
+  const spec = task.spec ?? {};
+  task.spec = spec;
+  if (task.type === undefined) task.type = component?.type ?? 'http';
+  if (task.request_body === undefined) task.request_body = spec.request_body ?? '';
+  if (task.path_params === undefined) task.path_params = spec.path_params;
+  if (task.query_params === undefined) task.query_params = spec.query_params;
+  return task;
+}
+
+/**
+ * Build a designer step `model` from a loaded task's spec for non-http types.
+ * Returns null for http (the caller keeps using the request_body flow).
+ */
+export function buildStepModelFromTaskSpec(
+  type: string,
+  taskSpec: any,
+  component: any,
+): any | null {
+  const spec = taskSpec ?? {};
+  const compSpec = component?.spec ?? {};
+  switch (type) {
+    case 'bash':
+      return { bash_command: spec.bash_command ?? compSpec.bash_command ?? '' };
+    case 'ssh':
+      return { command: spec.command ?? compSpec.command ?? '' };
+    case 'trigger_workflow':
+      return { conf: spec.conf ?? {} };
+    case 'http_xcom':
+      return {
+        request_body: spec.request_body ?? compSpec.request_body ?? '',
+        response_path: spec.response_path ?? compSpec.response_path ?? '',
+      };
+    case 'http':
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build the cm-cicada task `spec` (task-level fields only; component-level
+ * fields like api_connection_id/ssh_conn_id/trigger_dag_id are resolved from the
+ * task component) from a designer step's model/fixedModel for the given type.
+ */
+export function buildTaskSpecFromStep(
+  type: string,
+  model: any,
+  fixedModel: any,
+): Record<string, any> {
+  const m = model ?? {};
+  switch (type) {
+    case 'bash':
+      return { bash_command: m.bash_command ?? '' };
+    case 'ssh':
+      return { command: m.command ?? '' };
+    case 'trigger_workflow':
+      return { conf: m.conf ?? {} };
+    case 'http_xcom': {
+      const spec: Record<string, any> = { request_body: m.request_body ?? '' };
+      if (m.response_path) spec.response_path = m.response_path;
+      return spec;
+    }
+    case 'http':
+    default:
+      return {
+        request_body: JSON.stringify(m),
+        path_params: fixedModel?.path_params ?? {},
+        query_params: fixedModel?.query_params ?? {},
+      };
+  }
+}

--- a/front/src/entities/workflow/lib/schemaAdapter.ts
+++ b/front/src/entities/workflow/lib/schemaAdapter.ts
@@ -30,6 +30,22 @@ export const CUSTOM_EDITOR_TASK_TYPES: TaskType[] = [
 ];
 
 /**
+ * sequential-workflow-designer requires a step `type` matching
+ * /^[a-zA-Z][a-zA-Z0-9_-]+$/ (must start with a letter). Task component names
+ * like `_v2_bash_delay` (leading underscore) are rejected and break the whole
+ * designer/toolbox. This maps a task component name to a valid step type while
+ * the real name is kept on step.name / properties.originalData.task_component.
+ */
+export function toDesignerStepType(name: string): string {
+  const s = String(name ?? '');
+  if (/^[a-zA-Z][a-zA-Z0-9_-]+$/.test(s)) return s; // already valid — keep as-is
+  let t = s.replace(/[^a-zA-Z0-9_-]/g, '-');
+  if (!/^[a-zA-Z]/.test(t)) t = 'x' + t; // ensure it starts with a letter
+  if (t.length < 2) t += '0';
+  return t;
+}
+
+/**
  * Build the default legacy `options.request_body` string (parsed later into
  * step.properties.model) for a component of the given type.
  */

--- a/front/src/entities/workflow/model/stores.ts
+++ b/front/src/entities/workflow/model/stores.ts
@@ -4,6 +4,7 @@ import {
   IWorkflowResponse,
   ITaskComponent,
 } from '@/entities/workflow/model/types';
+import { normalizeTaskComponentInPlace } from '@/entities/workflow/lib/schemaAdapter';
 import { ref } from 'vue';
 
 const NAMESPACE = 'WORKFLOW';
@@ -52,14 +53,21 @@ export const useWorkflowStore = defineStore(NAMESPACE, () => {
   }
 
   function setTaskComponents(_taskComponents: ITaskComponent[]) {
-    taskComponents.value = _taskComponents.map(taskComponent => ({
-      created_at: taskComponent.created_at,
-      data: taskComponent.data,
-      id: taskComponent.id,
-      name: taskComponent.name,
-      description: '',
-      updated_at: taskComponent.updated_at,
-    }));
+    taskComponents.value = _taskComponents.map(taskComponent => {
+      // cm-cicada Type/Spec 응답을 legacy `data` 형태로 정규화 (idempotent).
+      // 정규화하지 않으면 `.data` 가 undefined 라 상세 JSON 뷰가 비어 보인다.
+      normalizeTaskComponentInPlace(taskComponent);
+      return {
+        created_at: taskComponent.created_at,
+        data: taskComponent.data,
+        id: taskComponent.id,
+        name: taskComponent.name,
+        description: '',
+        updated_at: taskComponent.updated_at,
+        type: (taskComponent as any).type,
+        spec: (taskComponent as any).spec,
+      };
+    });
     
     // 각 task component의 model 정보를 콘솔에 출력
     console.log('=== Task Components Model Information ===');

--- a/front/src/entities/workflow/model/types.ts
+++ b/front/src/entities/workflow/model/types.ts
@@ -34,6 +34,10 @@ export interface ITaskResponse {
   task_component: string;
   query_params?: any;
   id?: string;
+  // cm-cicada Type/Spec schema. `type` is resolved from the referenced task
+  // component; `spec` carries the task-level values (see schemaAdapter.ts).
+  type?: string;
+  spec?: Record<string, any>;
 }
 
 export interface ITaskComponentResponse {

--- a/front/src/features/sequential/designer/editor/model/editorProviders.ts
+++ b/front/src/features/sequential/designer/editor/model/editorProviders.ts
@@ -2,6 +2,19 @@ import { insertDynamicComponent } from '@/shared/utils';
 import { getSequencePath } from '@/features/sequential/designer/editor/model/utils';
 import TaskComponentEditor from '@/features/sequential/designer/editor/ui/TaskComponentEditor.vue';
 import ContainerNameEditor from '@/features/sequential/designer/editor/ui/ContainerNameEditor.vue';
+import BashTaskEditor from '@/features/sequential/designer/editor/ui/BashTaskEditor.vue';
+import SshTaskEditor from '@/features/sequential/designer/editor/ui/SshTaskEditor.vue';
+import HttpXcomTaskEditor from '@/features/sequential/designer/editor/ui/HttpXcomTaskEditor.vue';
+import TriggerWorkflowTaskEditor from '@/features/sequential/designer/editor/ui/TriggerWorkflowTaskEditor.vue';
+
+// cm-cicada task type → dedicated editor component. http (and unknown) falls
+// back to the schema-driven TaskComponentEditor.
+const TASK_TYPE_EDITOR: Record<string, any> = {
+  bash: BashTaskEditor,
+  ssh: SshTaskEditor,
+  http_xcom: HttpXcomTaskEditor,
+  trigger_workflow: TriggerWorkflowTaskEditor,
+};
 
 export function editorProviders() {
   const editor = document.createElement('div');
@@ -62,20 +75,17 @@ export function editorProviders() {
         );
       }
       if (step.componentType === 'task') {
-        // 🎯 모든 task에 대해 범용 TaskComponentEditor 사용
-        const TaskEditorComponent: any = TaskComponentEditor;
-        
-        // 디버깅을 위한 로그 추가
-        console.log('=== Task Editor Selection Debug ===');
+        // cm-cicada task type에 따라 전용 에디터 선택 (없으면 범용 TaskComponentEditor)
+        const taskType = step.properties?.taskType;
+        const TaskEditorComponent: any =
+          (taskType && TASK_TYPE_EDITOR[taskType]) || TaskComponentEditor;
+
+        console.log('=== Task Editor Selection ===');
         console.log('Step name:', step.name);
-        console.log('Step type:', step.type);
-        console.log('Step properties:', step.properties);
-        console.log('Step fixedModel:', step.properties?.fixedModel);
-        console.log('Task component from fixedModel:', step.properties?.fixedModel?.task_component);
-        console.log('Selected TaskComponentEditor for', step.name || step.type);
-        console.log('Final TaskEditorComponent:', TaskEditorComponent.name || TaskEditorComponent);
-        console.log('=====================================');
-        
+        console.log('Task type:', taskType);
+        console.log('Selected editor:', TaskEditorComponent?.name || 'TaskComponentEditor');
+        console.log('=============================');
+
         //toolboxModel에서 가공하는곳 참고
         insertDynamicComponent(
           TaskEditorComponent,

--- a/front/src/features/sequential/designer/editor/store/taskSchemaStore.ts
+++ b/front/src/features/sequential/designer/editor/store/taskSchemaStore.ts
@@ -6,6 +6,7 @@
 import { ref, computed } from 'vue';
 import { getTaskComponentList } from '@/features/sequential/designer/toolbox/model/api';
 import type { ITaskComponentInfoResponse } from '@/features/sequential/designer/toolbox/model/api';
+import { normalizeTaskComponentInPlace } from '@/entities/workflow/lib/schemaAdapter';
 
 interface TaskSchema {
   name: string;
@@ -54,6 +55,8 @@ class TaskSchemaStore {
         console.log(`Found ${response.responseData.length} task components`);
         
         response.responseData.forEach((taskComponent: ITaskComponentInfoResponse) => {
+          // cm-cicada Type/Spec 응답을 legacy 형태로 정규화 (idempotent)
+          normalizeTaskComponentInPlace(taskComponent);
           console.log(`Processing task component: ${taskComponent.name}`);
           console.log(`Has body_params:`, !!taskComponent.data?.body_params);
           

--- a/front/src/features/sequential/designer/editor/store/taskSchemaStore.ts
+++ b/front/src/features/sequential/designer/editor/store/taskSchemaStore.ts
@@ -88,7 +88,9 @@ class TaskSchemaStore {
         this.isLoaded.value = true;
         console.log(`Successfully loaded ${this.taskSchemas.value.size} task schemas`);
       } else {
-        throw new Error('No responseData found in API response');
+        // 데이터가 아직 없으면(비동기 로드 전) 조용히 반환 — 이후 watch 경로에서 다시 로드됨
+        console.warn('Task schemas: responseData not ready yet, skipping');
+        return;
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : 'Unknown error occurred';

--- a/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="custom-task-editor">
+    <div class="section-header"><h4>Bash Task</h4></div>
+
+    <div class="field">
+      <label class="field-label">Task Name</label>
+      <input
+        class="text-input"
+        type="text"
+        :value="name"
+        placeholder="Enter task name"
+        @input="onName"
+      />
+    </div>
+
+    <div class="field">
+      <label class="field-label">
+        Bash Command<span class="req">*</span>
+      </label>
+      <textarea
+        class="text-area"
+        rows="6"
+        :value="model.bash_command"
+        placeholder="e.g. echo 'hello world'"
+        @input="onCommand"
+      ></textarea>
+      <p class="hint">BashOperator로 실행될 셸 명령입니다.</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive, ref } from 'vue';
+import { Step } from '@/features/workflow/workflowEditor/model/types';
+
+export default defineComponent({
+  name: 'BashTaskEditor',
+  props: {
+    step: { type: Object as () => Step, required: true },
+  },
+  emits: ['saveComponentName', 'saveContext'],
+  setup(props, { emit }) {
+    const name = ref(props.step.name);
+    const model = reactive<{ bash_command: string }>({
+      bash_command: (props.step.properties.model as any)?.bash_command ?? '',
+    });
+
+    const onName = (e: Event) => {
+      const v = (e.target as HTMLInputElement).value;
+      name.value = v;
+      emit('saveComponentName', v);
+    };
+
+    const onCommand = (e: Event) => {
+      model.bash_command = (e.target as HTMLTextAreaElement).value;
+      emit('saveContext', { ...model });
+    };
+
+    return { name, model, onName, onCommand };
+  },
+});
+</script>
+
+<style scoped lang="postcss">
+.custom-task-editor {
+  @apply p-[16px] flex flex-col gap-[16px];
+}
+.section-header h4 {
+  @apply text-[16px] font-semibold;
+}
+.field {
+  @apply flex flex-col gap-[4px];
+}
+.field-label {
+  @apply text-[13px] font-medium text-gray-700;
+}
+.req {
+  @apply text-red-500 ml-[2px];
+}
+.text-input,
+.text-area {
+  @apply w-full border border-gray-300 rounded-[4px] p-[8px] text-[13px];
+}
+.text-area {
+  font-family: monospace;
+}
+.hint {
+  @apply text-[11px] text-gray-400;
+}
+</style>

--- a/front/src/features/sequential/designer/editor/ui/HttpXcomTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/HttpXcomTaskEditor.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="custom-task-editor">
+    <div class="section-header"><h4>HTTP (XCom) Task</h4></div>
+
+    <div class="field">
+      <label class="field-label">Task Name</label>
+      <input
+        class="text-input"
+        type="text"
+        :value="name"
+        placeholder="Enter task name"
+        @input="onName"
+      />
+    </div>
+
+    <div v-if="endpoint" class="field">
+      <label class="field-label">Endpoint</label>
+      <input class="text-input readonly" type="text" :value="`${method} ${endpoint}`" readonly />
+      <p class="hint">Task component에 고정된 API 요청입니다.</p>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Source Task (request body)<span class="req">*</span></label>
+      <input
+        class="text-input"
+        type="text"
+        :value="model.request_body"
+        placeholder="응답을 body로 사용할 이전 task 이름"
+        @input="onSource"
+      />
+      <p class="hint">지정한 task의 XCom 결과가 이 요청의 body로 전달됩니다.</p>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Response Path</label>
+      <input
+        class="text-input"
+        type="text"
+        :value="model.response_path"
+        placeholder="예: $.targetInfra (선택)"
+        @input="onResponsePath"
+      />
+      <p class="hint">이전 task 응답에서 추출할 JSONPath (선택).</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, reactive, ref } from 'vue';
+import { Step } from '@/features/workflow/workflowEditor/model/types';
+
+export default defineComponent({
+  name: 'HttpXcomTaskEditor',
+  props: {
+    step: { type: Object as () => Step, required: true },
+  },
+  emits: ['saveComponentName', 'saveContext'],
+  setup(props, { emit }) {
+    const name = ref(props.step.name);
+    const model = reactive<{ request_body: string; response_path: string }>({
+      request_body: (props.step.properties.model as any)?.request_body ?? '',
+      response_path: (props.step.properties.model as any)?.response_path ?? '',
+    });
+
+    const componentSpec = computed(
+      () => (props.step.properties as any)?.taskComponentData?.spec ?? {},
+    );
+    const endpoint = computed(() => componentSpec.value.endpoint ?? '');
+    const method = computed(() => componentSpec.value.method ?? '');
+
+    const onName = (e: Event) => {
+      const v = (e.target as HTMLInputElement).value;
+      name.value = v;
+      emit('saveComponentName', v);
+    };
+
+    const emitModel = () => emit('saveContext', { ...model });
+
+    const onSource = (e: Event) => {
+      model.request_body = (e.target as HTMLInputElement).value;
+      emitModel();
+    };
+
+    const onResponsePath = (e: Event) => {
+      model.response_path = (e.target as HTMLInputElement).value;
+      emitModel();
+    };
+
+    return { name, model, endpoint, method, onName, onSource, onResponsePath };
+  },
+});
+</script>
+
+<style scoped lang="postcss">
+.custom-task-editor {
+  @apply p-[16px] flex flex-col gap-[16px];
+}
+.section-header h4 {
+  @apply text-[16px] font-semibold;
+}
+.field {
+  @apply flex flex-col gap-[4px];
+}
+.field-label {
+  @apply text-[13px] font-medium text-gray-700;
+}
+.req {
+  @apply text-red-500 ml-[2px];
+}
+.text-input {
+  @apply w-full border border-gray-300 rounded-[4px] p-[8px] text-[13px];
+}
+.readonly {
+  @apply bg-gray-100 text-gray-500;
+}
+.hint {
+  @apply text-[11px] text-gray-400;
+}
+</style>

--- a/front/src/features/sequential/designer/editor/ui/SshTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/SshTaskEditor.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="custom-task-editor">
+    <div class="section-header"><h4>SSH Task</h4></div>
+
+    <div class="field">
+      <label class="field-label">Task Name</label>
+      <input
+        class="text-input"
+        type="text"
+        :value="name"
+        placeholder="Enter task name"
+        @input="onName"
+      />
+    </div>
+
+    <div v-if="sshConnId" class="field">
+      <label class="field-label">SSH Connection</label>
+      <input class="text-input readonly" type="text" :value="sshConnId" readonly />
+      <p class="hint">Task component에 고정된 SSH 연결입니다.</p>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Command<span class="req">*</span></label>
+      <textarea
+        class="text-area"
+        rows="6"
+        :value="model.command"
+        placeholder="e.g. df -h"
+        @input="onCommand"
+      ></textarea>
+      <p class="hint">원격 호스트에서 SSHOperator로 실행됩니다.</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, reactive, ref } from 'vue';
+import { Step } from '@/features/workflow/workflowEditor/model/types';
+
+export default defineComponent({
+  name: 'SshTaskEditor',
+  props: {
+    step: { type: Object as () => Step, required: true },
+  },
+  emits: ['saveComponentName', 'saveContext'],
+  setup(props, { emit }) {
+    const name = ref(props.step.name);
+    const model = reactive<{ command: string }>({
+      command: (props.step.properties.model as any)?.command ?? '',
+    });
+
+    const sshConnId = computed(
+      () => (props.step.properties as any)?.taskComponentData?.spec?.ssh_conn_id ?? '',
+    );
+
+    const onName = (e: Event) => {
+      const v = (e.target as HTMLInputElement).value;
+      name.value = v;
+      emit('saveComponentName', v);
+    };
+
+    const onCommand = (e: Event) => {
+      model.command = (e.target as HTMLTextAreaElement).value;
+      emit('saveContext', { ...model });
+    };
+
+    return { name, model, sshConnId, onName, onCommand };
+  },
+});
+</script>
+
+<style scoped lang="postcss">
+.custom-task-editor {
+  @apply p-[16px] flex flex-col gap-[16px];
+}
+.section-header h4 {
+  @apply text-[16px] font-semibold;
+}
+.field {
+  @apply flex flex-col gap-[4px];
+}
+.field-label {
+  @apply text-[13px] font-medium text-gray-700;
+}
+.req {
+  @apply text-red-500 ml-[2px];
+}
+.text-input,
+.text-area {
+  @apply w-full border border-gray-300 rounded-[4px] p-[8px] text-[13px];
+}
+.text-area {
+  font-family: monospace;
+}
+.readonly {
+  @apply bg-gray-100 text-gray-500;
+}
+.hint {
+  @apply text-[11px] text-gray-400;
+}
+</style>

--- a/front/src/features/sequential/designer/editor/ui/TriggerWorkflowTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/TriggerWorkflowTaskEditor.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="custom-task-editor">
+    <div class="section-header"><h4>Trigger Workflow Task</h4></div>
+
+    <div class="field">
+      <label class="field-label">Task Name</label>
+      <input
+        class="text-input"
+        type="text"
+        :value="name"
+        placeholder="Enter task name"
+        @input="onName"
+      />
+    </div>
+
+    <div v-if="triggerDagId" class="field">
+      <label class="field-label">Trigger Workflow (DAG)</label>
+      <input class="text-input readonly" type="text" :value="triggerDagId" readonly />
+      <p class="hint">Task component에 고정된 트리거 대상 워크플로우입니다.</p>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Conf (JSON)</label>
+      <textarea
+        class="text-area"
+        rows="8"
+        :value="confText"
+        placeholder='{ "key": "value" }'
+        @input="onConf"
+      ></textarea>
+      <p v-if="error" class="error">{{ error }}</p>
+      <p v-else class="hint">트리거되는 워크플로우로 전달할 conf 객체 (선택).</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref } from 'vue';
+import { Step } from '@/features/workflow/workflowEditor/model/types';
+
+export default defineComponent({
+  name: 'TriggerWorkflowTaskEditor',
+  props: {
+    step: { type: Object as () => Step, required: true },
+  },
+  emits: ['saveComponentName', 'saveContext'],
+  setup(props, { emit }) {
+    const name = ref(props.step.name);
+    const initialConf = (props.step.properties.model as any)?.conf ?? {};
+    const conf = ref<Record<string, any>>(initialConf);
+    const confText = ref(JSON.stringify(initialConf, null, 2));
+    const error = ref<string | null>(null);
+
+    const triggerDagId = computed(
+      () =>
+        (props.step.properties as any)?.taskComponentData?.spec?.trigger_dag_id ??
+        '',
+    );
+
+    const onName = (e: Event) => {
+      const v = (e.target as HTMLInputElement).value;
+      name.value = v;
+      emit('saveComponentName', v);
+    };
+
+    const onConf = (e: Event) => {
+      const raw = (e.target as HTMLTextAreaElement).value;
+      confText.value = raw;
+      const trimmed = raw.trim();
+      if (trimmed === '') {
+        error.value = null;
+        conf.value = {};
+        emit('saveContext', { conf: {} });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(raw);
+        error.value = null;
+        conf.value = parsed;
+        emit('saveContext', { conf: parsed });
+      } catch (err: any) {
+        error.value = 'Invalid JSON: ' + (err?.message ?? '');
+      }
+    };
+
+    return { name, confText, error, triggerDagId, onName, onConf };
+  },
+});
+</script>
+
+<style scoped lang="postcss">
+.custom-task-editor {
+  @apply p-[16px] flex flex-col gap-[16px];
+}
+.section-header h4 {
+  @apply text-[16px] font-semibold;
+}
+.field {
+  @apply flex flex-col gap-[4px];
+}
+.field-label {
+  @apply text-[13px] font-medium text-gray-700;
+}
+.text-input,
+.text-area {
+  @apply w-full border border-gray-300 rounded-[4px] p-[8px] text-[13px];
+}
+.text-area {
+  font-family: monospace;
+}
+.readonly {
+  @apply bg-gray-100 text-gray-500;
+}
+.hint {
+  @apply text-[11px] text-gray-400;
+}
+.error {
+  @apply text-[11px] text-red-500;
+}
+</style>

--- a/front/src/features/sequential/designer/toolbox/model/api/index.ts
+++ b/front/src/features/sequential/designer/toolbox/model/api/index.ts
@@ -7,6 +7,10 @@ export interface ITaskComponentInfoResponse {
   updated_at: string;
   id: string;
   name: string;
+  // cm-cicada Type/Spec schema (kept alongside the legacy `data` shape that the
+  // adapter fills in — see entities/workflow/lib/schemaAdapter.ts).
+  type?: string;
+  spec?: Record<string, any>;
   data: {
     options: {
       request_body: string;

--- a/front/src/features/sequential/designer/toolbox/model/toolboxModel.ts
+++ b/front/src/features/sequential/designer/toolbox/model/toolboxModel.ts
@@ -64,6 +64,8 @@ export function useSequentialToolboxModel() {
             model: modelData,
             originalData: mappingTaskInfoResponseITaskResponse(res),
             fixedModel: getFixedModel(res),
+            taskType: res.type ?? 'http', // cm-cicada task type (per-type editor 선택용)
+            taskComponentData: { ...res.data, spec: res.spec, type: res.type },
           },
         ),
       );
@@ -86,6 +88,8 @@ export function useSequentialToolboxModel() {
       request_body: taskInfoResponse.data.options.request_body,
       query_params: '',
       task_component: taskInfoResponse.name,
+      type: taskInfoResponse.type ?? 'http',
+      spec: taskInfoResponse.spec,
     };
   }
 

--- a/front/src/features/sequential/designer/toolbox/model/toolboxModel.ts
+++ b/front/src/features/sequential/designer/toolbox/model/toolboxModel.ts
@@ -7,6 +7,7 @@ import {
 } from '@/features/workflow/workflowEditor/model/types';
 import { toolboxSteps } from '@/features/sequential/designer/toolbox/model/toolboxSteps';
 import { ITaskResponse } from '@/entities';
+import { toDesignerStepType } from '@/entities/workflow/lib/schemaAdapter';
 
 export function useSequentialToolboxModel() {
   const loadStepsFunc = toolboxSteps();
@@ -59,7 +60,7 @@ export function useSequentialToolboxModel() {
         loadStepsFunc.defineBettleTaskStep(
           getRandomId(),
           res.name ?? 'undefined',  // name: toolbox에서는 원본 이름 표시, canvas 드롭 시 자동으로 고유 이름 생성
-          res.name,                  // type: task component 식별자
+          toDesignerStepType(res.name), // type: swd 유효 형식으로 정규화(실제 이름은 name/originalData 보존)
           {
             model: modelData,
             originalData: mappingTaskInfoResponseITaskResponse(res),

--- a/front/src/features/sequential/designer/toolbox/model/toolboxSteps.ts
+++ b/front/src/features/sequential/designer/toolbox/model/toolboxSteps.ts
@@ -70,6 +70,8 @@ export function toolboxSteps() {
           query_params: Record<string, string>;
         };
         originalData: any;
+        taskType?: string;
+        taskComponentData?: any;
       },
     ): Step {
       return {

--- a/front/src/features/sequential/designer/ui/SequentialDesigner.vue
+++ b/front/src/features/sequential/designer/ui/SequentialDesigner.vue
@@ -37,7 +37,10 @@ onMounted(function () {
 watch(
   () => props.sequence,
   () => {
-    const designer: Designer = sequentialDesignerModel.value.getDesigner();
+    const designer: Designer | null =
+      sequentialDesignerModel.value?.getDesigner();
+    // 디자이너가 아직 생성되지 않았으면(초기 마운트 전) 건너뜀
+    if (!designer) return;
     const definition: Definition = {
       properties: designer.getDefinition().properties,
       sequence: props.sequence,

--- a/front/src/features/workflow/workflowEditor/model/types.ts
+++ b/front/src/features/workflow/workflowEditor/model/types.ts
@@ -17,6 +17,11 @@ export interface Step extends _Step {
     model?: object;
     originalData?: ITaskResponse;
     fixedModel?: fixedModel;
+    // cm-cicada task type (http | http_xcom | bash | ssh | trigger_workflow),
+    // used to pick the per-type editor and to build the save-time spec.
+    taskType?: string;
+    // Normalized task component (`data` + `type`/`spec`) for schema-driven UI.
+    taskComponentData?: any;
   };
 }
 

--- a/front/src/features/workflow/workflowEditor/model/workflowEditorModel.ts
+++ b/front/src/features/workflow/workflowEditor/model/workflowEditorModel.ts
@@ -22,6 +22,7 @@ import {
   buildStepModelFromTaskSpec,
   buildTaskSpecFromStep,
   normalizeWorkflowTaskInPlace,
+  toDesignerStepType,
 } from '@/entities/workflow/lib/schemaAdapter';
 
 type dropDownType = {
@@ -232,7 +233,7 @@ export function useWorkflowToolModel() {
     return defineBettleTaskStep(
       getRandomId(),
       task.name,
-      task.task_component,
+      toDesignerStepType(task.task_component),
       stepProperties,
     );
   }

--- a/front/src/features/workflow/workflowEditor/model/workflowEditorModel.ts
+++ b/front/src/features/workflow/workflowEditor/model/workflowEditorModel.ts
@@ -18,6 +18,11 @@ import { isNullOrUndefined } from '@/shared/utils';
 import { reactive } from 'vue';
 import { useSequentialToolboxModel } from '@/features/sequential/designer/toolbox/model/toolboxModel';
 import { encodeBase64, decodeBase64 } from '@/shared/utils/base64';
+import {
+  buildStepModelFromTaskSpec,
+  buildTaskSpecFromStep,
+  normalizeWorkflowTaskInPlace,
+} from '@/entities/workflow/lib/schemaAdapter';
 
 type dropDownType = {
   name: string;
@@ -97,7 +102,10 @@ export function useWorkflowToolModel() {
         console.log(`  🔓 Unwrapping virtual group: ${taskGroup.name}`);
         
         if (taskGroup.tasks && taskGroup.tasks.length === 1) {
-          const task = taskGroup.tasks[0];
+          const task = normalizeWorkflowTaskInPlace(
+            taskGroup.tasks[0],
+            taskComponentList,
+          );
           const requestBody = getMappingWorkflowTaskComponentRequestBody(
             task,
             taskComponentList,
@@ -112,7 +120,8 @@ export function useWorkflowToolModel() {
         const designerTaskGroup = convertToDesignerTaskGroup(taskGroup);
         
         if (taskGroup.tasks) {
-          for (const task of taskGroup.tasks) {
+          for (const rawTask of taskGroup.tasks) {
+            const task = normalizeWorkflowTaskInPlace(rawTask, taskComponentList);
             const requestBody = getMappingWorkflowTaskComponentRequestBody(
               task,
               taskComponentList,
@@ -171,52 +180,61 @@ export function useWorkflowToolModel() {
     task: ITaskResponse,
     requestBody: string,
   ): Step {
-    const parsedString: any = parseRequestBody(requestBody);
-    
-    // Base64 decode content field for cicada_task_run_script
-    // cicada_task_run_script 태스크의 content 필드를 base64로 디코딩
-    if (task.task_component === 'cicada_task_run_script' && parsedString.content) {
-      console.log('🔓 Decoding content field for cicada_task_run_script');
-      console.log('   Encoded content:', parsedString.content);
-      parsedString.content = decodeBase64(parsedString.content);
-      console.log('   Decoded content:', parsedString.content);
-    }
-    
     // Task component 정보 찾기
     const taskComponent = taskComponentList.find(
-      tc => tc.name === task.task_component
+      tc => tc.name === task.task_component,
     );
-    
-    // Task component를 캔버스에 추가할 때 모델 정보를 콘솔에 출력
-    console.log('=== Task Component Added to Canvas ===');
-    console.log(`Task Name: ${task.name}`);
-    console.log(`Task Component: ${task.task_component}`);
-    console.log('Task Component Found:', !!taskComponent);
-    if (taskComponent) {
-      console.log('Task Component Schema (body_params):', taskComponent.data.body_params);
+
+    // cm-cicada task type 결정 (per-type editor 및 저장 spec 생성에 사용)
+    const taskType = task.type ?? taskComponent?.type ?? 'http';
+
+    // http 이외 타입(bash/ssh/http_xcom/trigger_workflow)은 spec에서 직접 model 구성
+    const customModel = buildStepModelFromTaskSpec(
+      taskType,
+      task.spec,
+      taskComponent,
+    );
+
+    let model: any;
+    let fixedModel: fixedModel;
+
+    if (customModel !== null) {
+      model = customModel;
+      fixedModel = { path_params: {}, query_params: {} };
+    } else {
+      // http: 기존 request_body → model 흐름 유지
+      model = parseRequestBody(requestBody);
+
+      // Base64 decode content field for cicada_task_run_script
+      if (task.task_component === 'cicada_task_run_script' && model.content) {
+        model.content = decodeBase64(model.content);
+      }
+
+      fixedModel = createFixedModel(task);
     }
-    console.log('Model Information:', {
-      requestBody: requestBody,
-      parsedModel: parsedString,
-      pathParams: task.path_params,
-      queryParams: task.query_params,
-      dependencies: task.dependencies
-    });
-    console.log('=====================================');
-    
-    // Step properties에 taskComponentData 추가
+
     const stepProperties: any = {
-      model: parsedString,
+      model,
       originalData: task,
-      fixedModel: createFixedModel(task),
+      fixedModel,
+      taskType,
     };
-    
-    // Task component data 추가 (schema 정보)
+
+    // Task component data 추가 (schema 정보 — http 폼 렌더링용 + 타입별 고정 필드 표시용)
     if (taskComponent) {
-      stepProperties.taskComponentData = taskComponent.data;
+      stepProperties.taskComponentData = {
+        ...taskComponent.data,
+        spec: taskComponent.spec,
+        type: taskComponent.type,
+      };
     }
-    
-    return defineBettleTaskStep(getRandomId(), task.name, task.task_component, stepProperties);
+
+    return defineBettleTaskStep(
+      getRandomId(),
+      task.name,
+      task.task_component,
+      stepProperties,
+    );
   }
 
   function convertToDesignerTaskGroup(taskGroup: ITaskGroupResponse): Step {
@@ -323,31 +341,40 @@ export function useWorkflowToolModel() {
     return result;
   }
 
-  function convertToCicadaTaskWithDependencies(step: Step, dependencies: string[]) {
+  function convertToCicadaTaskWithDependencies(
+    step: Step,
+    dependencies: string[],
+  ): any {
     if (step.componentType === 'task') {
-      // Base64 encode content field for cicada_task_run_script
-      const modelToSend: any = { ...step.properties.model };
       const taskComponent = step.properties.originalData?.task_component;
-      
+      const taskType =
+        step.properties.taskType ??
+        step.properties.originalData?.type ??
+        'http';
+
+      // Base64 encode content field for cicada_task_run_script (http only)
+      const modelToSend: any = { ...step.properties.model };
       if (taskComponent === 'cicada_task_run_script' && modelToSend.content) {
         modelToSend.content = encodeBase64(modelToSend.content);
       }
-      
-      const currentRequestBody = JSON.stringify(modelToSend);
-      const currentPathParams = step.properties.fixedModel?.path_params;
-      const currentQueryParams = step.properties.fixedModel?.query_params;
-      
+
+      // cm-cicada Type/Spec 스키마로 task spec 생성 (타입별 task-level 필드)
+      const spec = buildTaskSpecFromStep(
+        taskType,
+        modelToSend,
+        step.properties.fixedModel,
+      );
+
       console.log('\n=== Task Conversion ===');
       console.log('Task:', step.name);
+      console.log('Type:', taskType);
       console.log('Dependencies:', dependencies);
       console.log('Task Component:', taskComponent);
-      
+
       return {
         name: step.name,
-        request_body: currentRequestBody,
-        path_params: currentPathParams,
-        query_params: currentQueryParams,
-        task_component: step.properties.originalData?.task_component,
+        task_component: taskComponent,
+        spec,
         dependencies: dependencies,
       };
     }

--- a/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
+++ b/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
@@ -28,6 +28,7 @@ import getRandomId from '@/shared/utils/uuid';
 import { parseRequestBody } from '@/shared/utils/stringToObject';
 import SequentialDesigner from '@/features/sequential/designer/ui/SequentialDesigner.vue';
 import { DEFAULT_NAMESPACE } from '@/shared/constants/namespace';
+import { normalizeTaskComponentList } from '@/entities/workflow/lib/schemaAdapter';
 import { useTaskSchemaLoader } from '@/features/sequential/designer/editor/composables/useTaskSchemaLoader';
 
 interface IProps {
@@ -66,10 +67,14 @@ onBeforeMount(function () {
     resWorkflowTemplateData.execute(),
     resTaskComponentList.execute(),
   ]).then(res => {
+    // cm-cicada Type/Spec 응답을 디자이너가 소비하는 legacy 형태로 정규화 (in place).
+    // 팔레트/캔버스/템플릿 로드가 모두 이 배열을 참조하므로 여기서 한 번 변환한다.
+    normalizeTaskComponentList(res[1].data.responseData);
+
     workflowToolModel.workflowStore.setWorkflowTemplates(
       res[0].data.responseData,
     );
-    
+
     // cicada_task_run_script is now included in API response
     // cicada_task_run_script는 이제 API 응답에 포함됨
     workflowToolModel.setTaskComponent(res[1].data.responseData);


### PR DESCRIPTION
## Problem

Workflow Tool 작성 화면(예: `models/target-models` 진입)이 헤더와 Cancel/Save 버튼만 보이고 sequential-designer 캔버스가 비어 있는(`<!---->`) 채로 렌더링되며, 콘솔에 에러가 발생함.

## Root Cause

cm-cicada 가 task component / workflow task 를 **Type/Spec 스키마**로 리팩터링(cm-cicada v0.5.0 이후, `TaskComponent 모델을 Type/Spec 구조로 전환`)했음.

- task component: `{ id, name, description, type, spec, ... }` (`type ∈ {http, http_xcom, bash, ssh, trigger_workflow}`, `spec` 은 타입별 필드)
- workflow / template task: `{ name, task_component, spec, dependencies }`

반면 프런트는 여전히 구 스키마(`data.options.request_body`, `data.path_params/query_params/body_params`, task 의 flat 한 `request_body/path_params/query_params`)를 기대하고 있어, 신규 객체에서 `data.options.request_body` 접근 시 `TypeError` 가 발생 → 디자이너가 mount 되지 못함. 또한 신규 task 타입(bash/ssh/http_xcom/trigger_workflow)에 대한 지원이 없었음.

## Changes

- **`entities/workflow/lib/schemaAdapter.ts` 추가**: 두 스키마 간 변환 계층.
  - 읽기: cm-cicada 신규 task component / workflow·template task 를 디자이너가 소비하는 구 스키마 형태로 정규화 (`spec.*_schema` → `data.body_params/path_params/query_params`, `spec.{api_connection_id,endpoint,method,request_body}` → `data.options`). in place, idempotent.
  - 저장: 디자이너 상태를 타입별 task `spec` 으로 역변환하며, `cm-cicada/lib/airflow/gusty.go` 가 읽는 키와 일치시킴.
    - `http` → `request_body`, `path_params`, `query_params`
    - `http_xcom` → `request_body`, `response_path?`
    - `bash` → `bash_command` / `ssh` → `command` / `trigger_workflow` → `conf`
- cm-cicada task `type` 을 각 디자이너 step 에 실어, `editorProviders.ts` 에서 **타입별 전용 에디터로 분기**.
- **신규 에디터**: `BashTaskEditor`, `SshTaskEditor`, `HttpXcomTaskEditor`, `TriggerWorkflowTaskEditor`. `http` 는 기존 스키마 기반 `TaskComponentEditor` 를 그대로 사용. 컴포넌트 레벨 고정 필드(api_connection_id / ssh_conn_id / trigger_dag_id / endpoint)는 read-only 로 표시.
- 디자이너가 task component 목록을 소비하는 지점(`WorkflowEditor.vue`, `taskSchemaStore.ts`)에서 목록을 정규화하여, **팔레트에 모든 task 타입이 노출**되고 **template 불러오기**가 동작하도록 함.

백엔드 신규 엔드포인트는 필요 없음 — 타입별 편집 필드는 catalog `task_schema` 필드와 동일하며 기존 `list-task-component` / workflow 응답으로 모두 도출 가능.

## Verification

- `npm run build` 통과.
- 읽기/저장 어댑터를 **실제 cm-cicada API 데이터**(5개 타입 21개 task component + 4개 workflow template)에 대해 실행: 모든 컴포넌트가 `data.options` 크래시 없이 정규화되고, 모든 타입이 왕복(palette drag → save, template load → save) 시 gusty 가 요구하는 `spec` 키로 정확히 변환됨 — **108/108 통과**.
- 빌드 산출물을 구동 중인 `cm-butterfly-front` 컨테이너에 배포해 정상 서빙(HTTP 200) 확인.

브라우저 로그인이 필요한 화면이라 실제 클릭 동작 확인은 리뷰어 확인을 권장하며, 위 데이터 계약 검증으로 핵심 변환 로직을 확인함.
