### PR TITLE
feat(source): export selected source connections in the import layout

### DIFF
--- a/api/cmd/app/main.go
+++ b/api/cmd/app/main.go
@@ -88,6 +88,10 @@ func main() {
 	// so the interactive form and the import path share one set of rules.
 	api.POST("/parsetabularimport", handler.ParseTabularImport)
 
+	// Tabular export — builds a file from the selected connections in the same
+	// layout the importer reads, so the column contract lives in one place.
+	api.POST("/exporttabularconnections", handler.ExportTabularConnections)
+
 	// Project management endpoints
 	api.POST("/createproject", workspaceHandler.CreateProject)
 	api.POST("/getprojectlist", workspaceHandler.GetProjectList)

--- a/api/internal/handler/tabular_export.go
+++ b/api/internal/handler/tabular_export.go
@@ -1,0 +1,215 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"api/internal/util/response"
+
+	"github.com/labstack/echo/v4"
+	"github.com/xuri/excelize/v2"
+)
+
+// exportSheetName is the single sheet the Excel export writes into.
+const exportSheetName = "connections"
+
+// maxExportRows mirrors the import limit so both directions agree on how much
+// data is reasonable in one file.
+const maxExportRows = 1000
+
+// exportColumns is the column contract shared with the import template. The
+// order must stay identical to the template so an exported file can be fed
+// straight back into the importer.
+var exportColumns = []string{
+	"name",
+	"description",
+	"ip_address",
+	"ssh_port",
+	"user",
+	"password",
+	"private_key",
+}
+
+// encryptedColumns are written as headers with empty values. The connected
+// system returns these fields as ciphertext only, so there is no plaintext to
+// export. Writing the ciphertext would leak the values and also break a
+// re-import, because the importer would treat the ciphertext as a real
+// credential.
+var encryptedColumns = map[string]bool{
+	"user":        true,
+	"password":    true,
+	"private_key": true,
+}
+
+// TabularExportConnection is one connection to write out. The encrypted columns
+// are deliberately absent from this struct: the server never receives them, so
+// they cannot reach the file even if the console sends them by mistake.
+type TabularExportConnection struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	IPAddress   string `json:"ip_address"`
+	SSHPort     string `json:"ssh_port"`
+}
+
+// TabularExportRequest carries the connections the user selected.
+type TabularExportRequest struct {
+	// Format selects the output form: "csv" or "xlsx". An empty value means csv.
+	Format      string                    `json:"format"`
+	Connections []TabularExportConnection `json:"connections"`
+}
+
+// TabularExportResult carries the generated file.
+type TabularExportResult struct {
+	Format string `json:"format"`
+	// ContentBase64 holds the file bytes, matching how the import endpoint
+	// receives binary content. Keeping it base64 means the response shape does
+	// not change if a binary format such as xlsx is added later.
+	ContentBase64 string `json:"contentBase64"`
+}
+
+// ExportTabularConnections builds a file from the selected connections using the
+// same layout the importer reads. Generating it here, next to the parser, keeps
+// the column contract in one place so the two directions cannot drift apart.
+func ExportTabularConnections(c echo.Context) error {
+	req := new(TabularExportRequest)
+	if err := c.Bind(req); err != nil {
+		return response.BadRequest(c, "Invalid request body.")
+	}
+
+	format := strings.ToLower(strings.TrimSpace(req.Format))
+	if format == "" {
+		format = "csv"
+	}
+	if format != "csv" && format != "xlsx" {
+		return response.BadRequest(c, fmt.Sprintf("Unsupported export format: %s", req.Format))
+	}
+	if len(req.Connections) == 0 {
+		return response.BadRequest(c, "Select at least one connection to export.")
+	}
+	if len(req.Connections) > maxExportRows {
+		return response.BadRequest(c, fmt.Sprintf("Too many connections to export. (limit: %d)", maxExportRows))
+	}
+
+	raw, err := buildExportFile(format, req.Connections)
+	if err != nil {
+		return response.InternalServerError(c, "Failed to build the export file.")
+	}
+
+	return response.Success(c, &TabularExportResult{
+		Format:        format,
+		ContentBase64: base64.StdEncoding.EncodeToString(raw),
+	})
+}
+
+// buildExportFile writes the connections in the requested format. Both share
+// exportColumns and the empty-encrypted-column rule; only the container differs.
+func buildExportFile(format string, connections []TabularExportConnection) ([]byte, error) {
+	if format == "xlsx" {
+		return buildConnectionXLSX(connections)
+	}
+	return buildConnectionCSV(connections)
+}
+
+// buildConnectionCSV writes the header and one row per connection. encoding/csv
+// quotes values containing commas, quotes or newlines, so the result survives a
+// round trip through the import parser.
+func buildConnectionCSV(connections []TabularExportConnection) ([]byte, error) {
+	var buf bytes.Buffer
+
+	// Excel needs the byte order mark to read UTF-8 correctly, and our own
+	// template carries one. The import parser strips it, so it does not
+	// interfere when the file comes back.
+	buf.Write([]byte{0xEF, 0xBB, 0xBF})
+
+	w := csv.NewWriter(&buf)
+	if err := w.Write(exportColumns); err != nil {
+		return nil, err
+	}
+
+	for _, conn := range connections {
+		record := make([]string, 0, len(exportColumns))
+		for _, column := range exportColumns {
+			record = append(record, exportValue(conn, column))
+		}
+		if err := w.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// buildConnectionXLSX writes the same header and rows into an Excel workbook.
+// Users who find CSV awkward to edit (encoding, auto-formatting) get a file
+// Excel opens cleanly. The column contract is identical to the CSV path.
+func buildConnectionXLSX(connections []TabularExportConnection) ([]byte, error) {
+	f := excelize.NewFile()
+	defer func() { _ = f.Close() }()
+
+	index, err := f.NewSheet(exportSheetName)
+	if err != nil {
+		return nil, err
+	}
+	f.SetActiveSheet(index)
+	// NewFile seeds a default "Sheet1"; drop it so the importer reads ours first.
+	_ = f.DeleteSheet("Sheet1")
+
+	if err := writeXLSXRow(f, 1, exportColumns); err != nil {
+		return nil, err
+	}
+	for i, conn := range connections {
+		record := make([]string, 0, len(exportColumns))
+		for _, column := range exportColumns {
+			record = append(record, exportValue(conn, column))
+		}
+		if err := writeXLSXRow(f, i+2, record); err != nil {
+			return nil, err
+		}
+	}
+
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeXLSXRow(f *excelize.File, row int, values []string) error {
+	for col, value := range values {
+		cell, err := excelize.CoordinatesToCellName(col+1, row)
+		if err != nil {
+			return err
+		}
+		if err := f.SetCellStr(exportSheetName, cell, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// exportValue maps a column name onto the connection. Encrypted columns always
+// come back empty, whatever the caller sent.
+func exportValue(conn TabularExportConnection, column string) string {
+	if encryptedColumns[column] {
+		return ""
+	}
+	switch column {
+	case "name":
+		return conn.Name
+	case "description":
+		return conn.Description
+	case "ip_address":
+		return conn.IPAddress
+	case "ssh_port":
+		return conn.SSHPort
+	default:
+		return ""
+	}
+}

--- a/api/internal/handler/tabular_export_test.go
+++ b/api/internal/handler/tabular_export_test.go
@@ -1,0 +1,194 @@
+package handler
+
+import (
+	"bytes"
+	"testing"
+)
+
+func sampleConnections() []TabularExportConnection {
+	return []TabularExportConnection{
+		{Name: "web-01", Description: "front server", IPAddress: "10.0.0.1", SSHPort: "22"},
+		{Name: "db-01", Description: "database", IPAddress: "10.0.0.2", SSHPort: "2222"},
+	}
+}
+
+func TestBuildConnectionCSVHeaderMatchesImportTemplate(t *testing.T) {
+	raw, err := buildConnectionCSV(sampleConnections())
+	if err != nil {
+		t.Fatalf("buildConnectionCSV returned an error: %v", err)
+	}
+
+	res, err := parseTabular("export.csv", raw)
+	if err != nil {
+		t.Fatalf("the exported file could not be parsed back: %v", err)
+	}
+
+	if len(res.Headers) != len(exportColumns) {
+		t.Fatalf("header count = %d, want %d", len(res.Headers), len(exportColumns))
+	}
+	for i, want := range exportColumns {
+		if res.Headers[i] != want {
+			t.Errorf("header[%d] = %q, want %q", i, res.Headers[i], want)
+		}
+	}
+}
+
+func TestBuildConnectionCSVLeavesEncryptedColumnsEmpty(t *testing.T) {
+	raw, err := buildConnectionCSV(sampleConnections())
+	if err != nil {
+		t.Fatalf("buildConnectionCSV returned an error: %v", err)
+	}
+
+	res, err := parseTabular("export.csv", raw)
+	if err != nil {
+		t.Fatalf("the exported file could not be parsed back: %v", err)
+	}
+
+	for _, row := range res.Rows {
+		for column := range encryptedColumns {
+			if value := row.Data[column]; value != "" {
+				t.Errorf("row %d column %q = %q, want an empty value", row.Index, column, value)
+			}
+		}
+	}
+}
+
+// The exported file has to survive the importer, otherwise the two directions
+// have drifted apart. This is the check that catches that.
+func TestBuildConnectionCSVRoundTripsThroughTheImporter(t *testing.T) {
+	connections := []TabularExportConnection{
+		{Name: "web,01", Description: "has a comma", IPAddress: "10.0.0.1", SSHPort: "22"},
+		{Name: "db\"01", Description: "has a quote", IPAddress: "10.0.0.2", SSHPort: "22"},
+		{Name: "app-01", Description: "line one\nline two", IPAddress: "10.0.0.3", SSHPort: "22"},
+		// Multi-byte UTF-8, to prove the byte order mark does not corrupt
+		// non-ASCII names on the way out and back in again.
+		{Name: "wéb-ürsprung-01", Description: "años de café", IPAddress: "10.0.0.4", SSHPort: "22"},
+	}
+
+	raw, err := buildConnectionCSV(connections)
+	if err != nil {
+		t.Fatalf("buildConnectionCSV returned an error: %v", err)
+	}
+
+	res, err := parseTabular("export.csv", raw)
+	if err != nil {
+		t.Fatalf("the exported file could not be parsed back: %v", err)
+	}
+	if len(res.Rows) != len(connections) {
+		t.Fatalf("row count = %d, want %d", len(res.Rows), len(connections))
+	}
+
+	for i, want := range connections {
+		got := res.Rows[i].Data
+		if got["name"] != want.Name {
+			t.Errorf("row %d name = %q, want %q", i+1, got["name"], want.Name)
+		}
+		if got["description"] != want.Description {
+			t.Errorf("row %d description = %q, want %q", i+1, got["description"], want.Description)
+		}
+		if got["ip_address"] != want.IPAddress {
+			t.Errorf("row %d ip_address = %q, want %q", i+1, got["ip_address"], want.IPAddress)
+		}
+		if got["ssh_port"] != want.SSHPort {
+			t.Errorf("row %d ssh_port = %q, want %q", i+1, got["ssh_port"], want.SSHPort)
+		}
+	}
+}
+
+func TestBuildConnectionCSVStartsWithBOM(t *testing.T) {
+	raw, err := buildConnectionCSV(sampleConnections())
+	if err != nil {
+		t.Fatalf("buildConnectionCSV returned an error: %v", err)
+	}
+	if !bytes.HasPrefix(raw, []byte{0xEF, 0xBB, 0xBF}) {
+		t.Error("the exported file does not start with a UTF-8 byte order mark")
+	}
+}
+
+// The Excel path shares the column contract with CSV and must survive the same
+// round trip through the importer, which reads .xlsx as well.
+func TestBuildConnectionXLSXRoundTripsThroughTheImporter(t *testing.T) {
+	connections := []TabularExportConnection{
+		{Name: "web,01", Description: "has a comma", IPAddress: "10.0.0.1", SSHPort: "22"},
+		{Name: "app-01", Description: "line one\nline two", IPAddress: "10.0.0.3", SSHPort: "2222"},
+		{Name: "wéb-ürsprung-01", Description: "años de café", IPAddress: "10.0.0.4", SSHPort: "22"},
+	}
+
+	raw, err := buildConnectionXLSX(connections)
+	if err != nil {
+		t.Fatalf("buildConnectionXLSX returned an error: %v", err)
+	}
+
+	// The importer detects xlsx by extension, so name it accordingly.
+	res, err := parseTabular("export.xlsx", raw)
+	if err != nil {
+		t.Fatalf("the exported workbook could not be parsed back: %v", err)
+	}
+	if res.Format != "xlsx" {
+		t.Errorf("format = %q, want xlsx", res.Format)
+	}
+	if len(res.Headers) != len(exportColumns) {
+		t.Fatalf("header count = %d, want %d", len(res.Headers), len(exportColumns))
+	}
+	for i, want := range exportColumns {
+		if res.Headers[i] != want {
+			t.Errorf("header[%d] = %q, want %q", i, res.Headers[i], want)
+		}
+	}
+	if len(res.Rows) != len(connections) {
+		t.Fatalf("row count = %d, want %d", len(res.Rows), len(connections))
+	}
+	for i, want := range connections {
+		got := res.Rows[i].Data
+		if got["name"] != want.Name {
+			t.Errorf("row %d name = %q, want %q", i+1, got["name"], want.Name)
+		}
+		if got["ip_address"] != want.IPAddress {
+			t.Errorf("row %d ip_address = %q, want %q", i+1, got["ip_address"], want.IPAddress)
+		}
+		if got["ssh_port"] != want.SSHPort {
+			t.Errorf("row %d ssh_port = %q, want %q", i+1, got["ssh_port"], want.SSHPort)
+		}
+		for column := range encryptedColumns {
+			if got[column] != "" {
+				t.Errorf("row %d column %q = %q, want empty", i+1, column, got[column])
+			}
+		}
+	}
+}
+
+func TestBuildExportFileRejectsUnknownFormat(t *testing.T) {
+	// buildExportFile itself does not gate the format (the handler does), but the
+	// two known formats must each produce something parseable.
+	for _, format := range []string{"csv", "xlsx"} {
+		raw, err := buildExportFile(format, sampleConnections())
+		if err != nil {
+			t.Fatalf("buildExportFile(%q) error: %v", format, err)
+		}
+		if len(raw) == 0 {
+			t.Errorf("buildExportFile(%q) produced no bytes", format)
+		}
+	}
+}
+
+// A caller cannot smuggle credentials into the file: the request type has no
+// field for them, so the writer always emits empty values.
+func TestBuildConnectionCSVAlwaysEmitsEveryColumn(t *testing.T) {
+	raw, err := buildConnectionCSV([]TabularExportConnection{{Name: "only-name"}})
+	if err != nil {
+		t.Fatalf("buildConnectionCSV returned an error: %v", err)
+	}
+
+	res, err := parseTabular("export.csv", raw)
+	if err != nil {
+		t.Fatalf("the exported file could not be parsed back: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("row count = %d, want 1", len(res.Rows))
+	}
+	for _, column := range exportColumns {
+		if _, ok := res.Rows[0].Data[column]; !ok {
+			t.Errorf("column %q is missing from the exported row", column)
+		}
+	}
+}

--- a/front/src/entities/sourceConnection/api/tabularExport.ts
+++ b/front/src/entities/sourceConnection/api/tabularExport.ts
@@ -1,0 +1,35 @@
+import { IAxiosResponse, useAxiosPost } from '@/shared/libs';
+
+/**
+ * The file is built on the server, next to the import parser, so both
+ * directions share one column contract. Encrypted fields have no place in the
+ * request: the server cannot write what it never receives.
+ */
+const EXPORT_TABULAR_CONNECTIONS = 'exporttabularconnections';
+
+/** Only the columns the server is allowed to write out. */
+export interface ITabularExportConnection {
+  name: string;
+  description: string;
+  ip_address: string;
+  ssh_port: string;
+}
+
+export interface ITabularExportRequest {
+  /** Currently only 'csv'. */
+  format: string;
+  connections: ITabularExportConnection[];
+}
+
+export interface ITabularExportResult {
+  format: string;
+  /** File bytes as base64, so a binary format can be added without a change here. */
+  contentBase64: string;
+}
+
+export function useExportTabularConnections() {
+  return useAxiosPost<
+    IAxiosResponse<ITabularExportResult>,
+    ITabularExportRequest | null
+  >(EXPORT_TABULAR_CONNECTIONS, null);
+}

--- a/front/src/shared/utils/exportFileName/index.ts
+++ b/front/src/shared/utils/exportFileName/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Names for files the console hands to the browser.
+ *
+ * The rules here stay deliberately modest: take out only what an operating
+ * system refuses to store, and add a timestamp so exporting the same thing
+ * twice does not quietly overwrite the earlier file. Preserving names more
+ * faithfully — length policy, non-ASCII handling, duplicate counters — is a
+ * separate piece of work, and this module is the single place it will change.
+ */
+
+/** Characters no common operating system accepts in a file name. */
+const UNSAFE_CHARACTERS = /[\\/:*?"<>|]/g;
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\x00-\x1f\x7f]/g;
+
+const MAX_BASE_LENGTH = 80;
+const FALLBACK_BASE = 'connections';
+
+/**
+ * Make a name safe to save.
+ *
+ * Korean characters and spaces are left as they are. They download without
+ * trouble, and stripping them would leave a name nobody could recognise.
+ */
+export function toSafeFileBaseName(name: string | null | undefined): string {
+  const safe = (name ?? '')
+    .replace(CONTROL_CHARACTERS, '')
+    .replace(UNSAFE_CHARACTERS, '-')
+    .replace(/-{2,}/g, '-')
+    // Windows drops a trailing dot or space, which would change the name
+    // without telling anyone.
+    .replace(/^[\s.]+|[\s.]+$/g, '')
+    .slice(0, MAX_BASE_LENGTH)
+    .replace(/^[\s.-]+|[\s.-]+$/g, '');
+
+  return safe || FALLBACK_BASE;
+}
+
+/** Local time, in the same shape the JSON export already uses. */
+export function exportTimestamp(date: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}` +
+    `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+  );
+}
+
+/**
+ * Build the download name. The timestamp is what keeps repeated exports of the
+ * same connections from landing on top of each other.
+ */
+export function buildExportFileName(
+  baseName: string | null | undefined,
+  extension: string,
+  date: Date = new Date(),
+): string {
+  return `${toSafeFileBaseName(baseName)}-${exportTimestamp(date)}.${extension}`;
+}

--- a/front/src/shared/utils/index.ts
+++ b/front/src/shared/utils/index.ts
@@ -4,3 +4,4 @@ export * from '@/shared/utils/notice-alert-helper';
 export * from '@/shared/utils/dateformatter';
 export * from '@/shared/utils/isNullOrUndefined';
 export * from '@/shared/utils/connectionValidation';
+export * from '@/shared/utils/exportFileName';

--- a/front/src/widgets/source/sourceConnections/sourceConnectionList/ui/SourceConnectionList.vue
+++ b/front/src/widgets/source/sourceConnections/sourceConnectionList/ui/SourceConnectionList.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
-import { PToolboxTable, PButton, PButtonModal, PHorizontalLayout } from '@cloudforet-test/mirinae';
 import {
+  PToolboxTable,
+  PButton,
+  PButtonModal,
+  PHorizontalLayout,
+  PRadio,
+  PRadioGroup,
+} from '@cloudforet-test/mirinae';
+import {
+  buildExportFileName,
   insertDynamicComponent,
   showErrorMessage,
   showSuccessMessage,
@@ -10,6 +18,11 @@ import { onBeforeMount, onMounted, reactive, watch, computed, ref, nextTick } fr
 import TableLoadingSpinner from '@/shared/ui/LoadingSpinner/TableLoadingSpinner.vue';
 import { useSourceConnectionListModel } from '@/widgets/source/sourceConnections/sourceConnectionList/model/sourceConnectionListModel';
 import { useBulkDeleteSourceConnection } from '@/entities/sourceConnection/api';
+import {
+  ITabularExportConnection,
+  useExportTabularConnections,
+} from '@/entities/sourceConnection/api/tabularExport';
+import { useSourceServiceStore } from '@/entities/sourceService/model/stores';
 import DynamicTableIconButton from '@/shared/ui/Button/dynamicIconButton/DynamicTableIconButton.vue';
 import { useDynamicTableHeight } from '@/shared/hooks/table/useDynamicTableHeight';
 import { useToolboxTableHeight } from '@/shared/hooks/table/useToolboxTableHeight';
@@ -50,7 +63,26 @@ const tableKey = ref(0); // key for re-rendering the component
 
 const modals = reactive({
   alertModalState: { open: false },
+  exportModalState: { open: false },
 });
+
+const sourceServiceStore = useSourceServiceStore();
+const exportConnections = useExportTabularConnections();
+const isExporting = ref(false);
+
+// CSV opens everywhere but can be awkward to edit (encoding, auto-formatting);
+// Excel is offered as an alternative. CSV stays the default.
+type ExportFormat = 'csv' | 'xlsx';
+const exportFormat = ref<ExportFormat>('csv');
+const exportFormatOptions: { label: string; value: ExportFormat }[] = [
+  { label: 'CSV', value: 'csv' },
+  { label: 'Excel (.xlsx)', value: 'xlsx' },
+];
+
+// The table is a mirinae component whose selection is not a real checkbox, so
+// the selected row indexes are the only reliable signal here.
+const selectedCount = computed(() => tableModel.tableState.selectIndex.length);
+const hasSelection = computed(() => selectedCount.value > 0);
 
 watch(
   props,
@@ -145,6 +177,98 @@ function handleDeleteConnections() {
   }
 }
 
+// Read the checked rows the same way the delete flow does.
+function selectedSourceConnections() {
+  return tableModel.tableState.selectIndex
+    .map(selectIndex => tableModel.tableState.displayItems[selectIndex])
+    .filter(item => !!item);
+}
+
+function handleExportClick() {
+  // A mirinae button renders disabled as a class only, so the click still
+  // reaches this handler. Stop here rather than trusting the attribute.
+  if (!hasSelection.value || isExporting.value) return;
+  exportFormat.value = 'csv'; // reset to the default each time the dialog opens
+  modals.exportModalState.open = true;
+}
+
+// The file name uses the connection name for a single row and the source group
+// name for several, and always carries a timestamp so exporting twice does not
+// overwrite the earlier file.
+function exportBaseName(rows: ReturnType<typeof selectedSourceConnections>) {
+  if (rows.length === 1) return rows[0].name;
+  return sourceServiceStore.getServiceById(props.selectedServiceId)?.name ?? '';
+}
+
+const EXPORT_MIME: Record<ExportFormat, string> = {
+  csv: 'text/csv;charset=utf-8;',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+function downloadExportedFile(
+  contentBase64: string,
+  fileName: string,
+  format: ExportFormat,
+) {
+  const binary = atob(contentBase64);
+  const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
+  const blob = new Blob([bytes], { type: EXPORT_MIME[format] });
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+async function handleExportConfirm() {
+  modals.exportModalState.open = false;
+
+  const rows = selectedSourceConnections();
+  if (!rows.length) return;
+
+  // Only the columns the server writes out. Encrypted fields are never sent,
+  // so they cannot end up in the file.
+  const connections: ITabularExportConnection[] = rows.map(row => ({
+    name: row.originalData?.name ?? '',
+    description: row.originalData?.description ?? '',
+    ip_address: row.originalData?.ip_address ?? '',
+    ssh_port: String(row.originalData?.ssh_port ?? ''),
+  }));
+
+  const format = exportFormat.value;
+  isExporting.value = true;
+  try {
+    const { data } = await exportConnections.execute({
+      format,
+      connections,
+    });
+
+    if (data?.status?.code !== 200 || !data?.responseData?.contentBase64) {
+      showErrorMessage(
+        'Export Failed',
+        data?.status?.message || 'The export file could not be created.',
+      );
+      return;
+    }
+
+    downloadExportedFile(
+      data.responseData.contentBase64,
+      buildExportFileName(exportBaseName(rows), format),
+      format,
+    );
+    showSuccessMessage('success', `Exported ${rows.length} connection(s).`);
+  } catch (error) {
+    showErrorMessage(
+      'Export Failed',
+      toErrorMessage(error, 'The export file could not be created.'),
+    );
+  } finally {
+    isExporting.value = false;
+  }
+}
+
 function addDeleteIconAtTable() {
   const toolboxTable = this.$refs.toolboxTable.$el;
   const targetElement = toolboxTable.querySelector('.right-tool-group');
@@ -231,6 +355,16 @@ function handleSourceConnectionList() {
               >
                 Add / Edit
               </p-button>
+              <p-button
+                data-testid="source-connection-export"
+                class="ml-2"
+                style-type="secondary"
+                icon-left="ic_download"
+                :disabled="!hasSelection || isExporting"
+                @click="handleExportClick"
+              >
+                Export
+              </p-button>
             </template>
           </p-toolbox-table>
         </template>
@@ -255,7 +389,52 @@ function handleSourceConnectionList() {
         }
       "
     />
+    <!-- Asked before the download so nobody is surprised by the blank
+         credential columns after opening the file. -->
+    <p-button-modal
+      v-model="modals.exportModalState.open"
+      :visible="modals.exportModalState.open"
+      size="sm"
+      backdrop
+      header-title="Export connections"
+      @confirm="handleExportConfirm"
+    >
+      <template #body>
+        <p data-testid="source-connection-export-notice">
+          The encrypted columns (user, password, private key) are not included
+          in the export. Fill them in yourself before importing the file again.
+        </p>
+        <p class="mt-2">{{ selectedCount }} connection(s) will be exported.</p>
+        <div class="export-format mt-2">
+          <span class="export-format-label">File format</span>
+          <p-radio-group>
+            <p-radio
+              v-for="option in exportFormatOptions"
+              :key="option.value"
+              v-model="exportFormat"
+              :value="option.value"
+              :data-testid="`source-connection-export-format-${option.value}`"
+            >
+              <span>{{ option.label }}</span>
+            </p-radio>
+          </p-radio-group>
+        </div>
+      </template>
+      <template #confirm-button>
+        <span data-testid="source-connection-export-confirm">Export</span>
+      </template>
+      <template #close-button>
+        <span data-testid="source-connection-export-cancel">Cancel</span>
+      </template>
+    </p-button-modal>
   </div>
 </template>
 
-<style scoped lang="postcss"></style>
+<style scoped lang="postcss">
+.export-format {
+  @apply flex items-center gap-[0.75rem];
+}
+.export-format-label {
+  @apply text-[0.8125rem] text-gray-600;
+}
+</style>


### PR DESCRIPTION
## What

The connection list under a source group could import connections from a CSV or Excel file, but there was no way to get them back out. This adds an **Export** button next to *Add / Edit* that downloads the checked connections. The format is chosen in a confirmation dialog — **CSV or Excel (.xlsx)**, defaulting to CSV.

## How

The file is built on the server, next to the import parser, so the import and export sides share one column layout and cannot drift apart. No new dependency is added and nothing is added to the browser bundle — the tabular libraries are already present for the import path, and the Excel file is written with the same one.

The encrypted columns (user, password, private key) are written as headers with **empty values**. The connected system returns those fields as ciphertext only, so there is no plaintext to export; writing the ciphertext would both leak the values and break a re-import, since the importer would read it as a real credential. The request type has no field for them at all, so they cannot reach the file even by mistake, and the confirmation dialog states this before the download starts.

File names use the connection name for a single row and the source group name for several, with a timestamp so exporting the same connections twice does not overwrite the earlier file.

## Tests

Unit tests feed the exported CSV and xlsx back through the import parser and confirm the values round-trip (including commas, quotes, embedded newlines and non-ASCII).