### PR TITLE
fix(workload): cap the load test progress bar at the width of the step list

### DIFF
--- a/front/src/widgets/workload/vm/loadTestProgress/ui/LoadTestProgress.vue
+++ b/front/src/widgets/workload/vm/loadTestProgress/ui/LoadTestProgress.vue
@@ -393,7 +393,7 @@ const hasSteps = computed(() => steps.value.length > 0);
       >
         {{ primaryLine }}
       </p>
-      <div class="lt-bar-row">
+      <div class="lt-bar-row" :class="{ 'is-full': variant === 'full' }">
         <div class="lt-bar" data-testid="load-test-progress-bar">
           <div
             class="lt-fill"
@@ -525,6 +525,16 @@ const hasSteps = computed(() => steps.value.length > 0);
   align-items: center;
   gap: 8px;
   height: 16px;
+}
+
+/* Full panel: cap the row at roughly the width of the step lines below it, so the percentage
+   and the polling spinner sit next to the bar instead of against the right edge of a wide
+   panel — far from the left-aligned step text the eye is already on. Only the full variant is
+   capped; the compact cell in the Information tab keeps filling its column. It is a cap, not a
+   fixed width, so a narrower browser shrinks the whole row with the panel. */
+.lt-bar-row.is-full {
+  width: 100%;
+  max-width: 640px;
 }
 
 .lt-bar {


### PR DESCRIPTION
## What was wrong

While a load test runs, the Evaluate Perf tab shows a progress bar above the step list. The bar row stretched the full width of the panel, so on a wide screen the percentage and the polling spinner ended up against the right edge while the step list stayed left-aligned.

That put the two things a user reads together — *which step is running* and *is it still moving* — at opposite ends of the screen. Measured on a 1920 px browser: the bar row was 1,255 px wide while the step text below it occupied about 405 px. The remaining ~850 px was empty, with a 12 px spinner turning alone at the far end.

## What changed

One file, two places: the bar row of the full panel gets a cap.

```
<div class="lt-bar-row" :class="{ 'is-full': variant === 'full' }">

.lt-bar-row.is-full { width: 100%; max-width: 480px; }
```

- It is a **cap, not a fixed width**. When the panel is wider the row stops at the cap; when it is narrower the whole row (bar + percentage + spinner) shrinks along with the panel.
- **Only the full panel is capped.** The same component is also used as a compact cell in the Information tab's Load Status column and as a status badge; those are unchanged and keep filling their column.
- The cap is not tied to the step text with `fit-content`, deliberately: step messages change on every poll, so the bar width would shift each time and the panel would jitter.
- The spinner keeps its size and animation. Only its position moves, next to the percentage.

## Verification

Deployed and checked on a running console, across 7 browser widths and 4 execution states.

| Browser width | Before | After |
|---:|---:|---:|
| 1920 | 1,255 px | **480 px** |
| 1280 | 615 px | **480 px** |
| 1024 and below | panel width | panel width (**unchanged**) |

- No horizontal scrollbar appears at any width from 500 to 1920 px (document scroll width equals the viewport at every step).
- Where the panel is already narrower than the cap, the measurements are **identical to before** — there is no width at which this change makes the layout worse.
- Also checked with a phase that reports no sub-steps (indeterminate sweep bar), a failed run (failure panel and step list, no bar), a completed run (results view), and the Information tab's compact cell (the new class is not applied there).