### PR TITLE
fix(workflow): say so when a requested run never appears, instead of quietly redrawing

### DIFF
--- a/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/model/workflowRunViewerModel.ts
@@ -194,16 +194,27 @@ export function useWorkflowRunViewerModel() {
     }
   }
 
-  async function loadRuns(wfId: string) {
+  /**
+   * Returns the reason it failed, or null on success.
+   *
+   * The caller decides what a failure means. Opening a workflow treats it as "has never run"
+   * (see below), but while we are waiting for a run we just started, the same failure means
+   * *we could not check* — and the user has to be told that rather than left watching a
+   * spinner forever.
+   */
+  async function loadRuns(wfId: string): Promise<string | null> {
     try {
       const { data, execute } = useGetWorkflowRuns(wfId);
       await execute();
       runs.value = data.value?.responseData ?? [];
-    } catch {
+      return null;
+    } catch (e: any) {
       // A workflow that has never run fails to load from the engine — before Airflow has read the
       // new DAG, it appears not to exist. **This is not a failure but "not yet"**, so instead of a
       // red error we show an empty state that invites the user to run it.
-      runs.value = [];
+      // We do not clear the list here: `open()` clears it before calling, and the run-wait loop
+      // must not wipe the run it is still showing just because one query failed.
+      return e?.message ?? 'Failed to load the run history.';
     }
   }
 
@@ -488,6 +499,88 @@ export function useWorkflowRunViewerModel() {
 
   /** A run has been requested and we are waiting for it to appear — drives the screen's lock */
   const runStarting = ref(false);
+  /**
+   * The wait ran out without the run showing up. **This is not "the run failed"** — the engine
+   * accepted the request and may well be running it. What we know is only that we could not
+   * confirm it, so the screen says exactly that and lets the user decide whether to keep
+   * waiting or stop looking.
+   */
+  const runStartTimedOut = ref(false);
+  /** Why the last check failed, when it failed. Empty when the run simply did not appear. */
+  const runStartError = ref<string | null>(null);
+
+  /** What the pending wait is about, so "keep waiting" can resume it */
+  let pendingRunWfId: string | null = null;
+  let pendingKnownRunIds = new Set<string>();
+
+  /**
+   * Wait for the run we just requested to appear in the run history.
+   *
+   * On the way out this used to reopen the whole screen, which threw away what the user was
+   * looking at and *said nothing* — the screen came back looking normal while the run was
+   * nowhere to be seen. Now we stop, keep the screen as it is, and say what happened.
+   */
+  async function waitForNewRun(wfId: string): Promise<void> {
+    runStarting.value = true;
+    runStartTimedOut.value = false;
+    runStartError.value = null;
+
+    const deadline = Date.now() + NEW_RUN_TIMEOUT_MS;
+    let lastError: string | null = null;
+
+    for (;;) {
+      lastError = await loadRuns(wfId);
+      // Identify it by "a run id we had not seen", not by time — the engine's clock and
+      // ours are different clocks, and sorting by start_date would pick the previous run
+      // whenever they disagree.
+      const started = runs.value.find(
+        r => !pendingKnownRunIds.has(r.workflow_run_id),
+      );
+      if (started) {
+        await selectRun(wfId, started.workflow_run_id);
+        runStarting.value = false;
+        return;
+      }
+      if (Date.now() + NEW_RUN_INTERVAL_MS > deadline) break;
+      await new Promise(resolve => setTimeout(resolve, NEW_RUN_INTERVAL_MS));
+    }
+
+    /*
+      A single failed query is not reported: right after a workflow is created the engine
+      answers 404 until it has registered the DAG, and calling that an error would cry wolf on
+      a perfectly normal first run. What matters is whether it was *still* failing when the
+      wait ran out — that is the case where the user needs the reason, not just "not yet".
+    */
+    runStartError.value = lastError;
+    runStartTimedOut.value = true;
+  }
+
+  /** The user chose to wait longer — same wait again, from now */
+  async function keepWaitingForRun(): Promise<void> {
+    if (!pendingRunWfId) return;
+    await waitForNewRun(pendingRunWfId);
+  }
+
+  /**
+   * The user chose to stop waiting.
+   *
+   * **This does not cancel the run** — there is no path from here that stops it, and the engine
+   * may well be running it. It only stops us looking for it.
+   *
+   * We do refresh once on the way out, because after all that waiting the screen may no longer
+   * match reality. Reopening is safe in both directions: with no history at all the screen falls
+   * back to the un-run state, and after a re-run the latest run is picked up again. What was
+   * wrong before was reopening *silently at the timeout*, as if nothing had been asked — doing
+   * it because the user asked to stop is a different thing.
+   */
+  async function stopWaitingForRun(): Promise<void> {
+    const wfId = pendingRunWfId;
+    runStarting.value = false;
+    runStartTimedOut.value = false;
+    runStartError.value = null;
+    pendingRunWfId = null;
+    if (wfId) await open(wfId);
+  }
 
   /** Run directly from the viewer — no need to go to the list screen */
   async function runWorkflow() {
@@ -497,39 +590,33 @@ export function useWorkflowRunViewerModel() {
     // Turn this on *before* the request. What the user is waiting on starts at the click,
     // not at the response.
     runStarting.value = true;
+    runStartTimedOut.value = false;
+    runStartError.value = null;
     loadError.value = null;
+
+    pendingRunWfId = wfId;
+    pendingKnownRunIds = new Set(runs.value.map(r => r.workflow_run_id));
+
     try {
-      const known = new Set(runs.value.map(r => r.workflow_run_id));
       const { execute } = useRunWorkflow(wfId);
       await execute();
-      // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
-      // The name has to be captured here — at completion there is only the run id.
-      void trackWorkflow({
-        wfId,
-        label: workflow.value?.name || wfId,
-        action: 'run',
-      });
-
-      const deadline = Date.now() + NEW_RUN_TIMEOUT_MS;
-      let started: IWorkflowRun | undefined;
-      for (;;) {
-        await loadRuns(wfId);
-        // Identify it by "a run id we had not seen", not by time — the engine's clock and
-        // ours are different clocks, and sorting by start_date would pick the previous run
-        // whenever they disagree.
-        started = runs.value.find(r => !known.has(r.workflow_run_id));
-        if (started) break;
-        if (Date.now() + NEW_RUN_INTERVAL_MS > deadline) break;
-        await new Promise(resolve => setTimeout(resolve, NEW_RUN_INTERVAL_MS));
-      }
-
-      // If it never showed up, do not leave the screen on the old run pretending nothing
-      // happened — reopen so at least what *is* readable is drawn, and the run list is fresh.
-      if (started) await selectRun(wfId, started.workflow_run_id);
-      else await open(wfId);
-    } finally {
-      runStarting.value = false;
+    } catch (e: any) {
+      // The request itself was refused — that *is* a failure, and it is a different one from
+      // "we cannot find the run". Say so and stop; there is nothing to wait for.
+      runStartError.value = e?.message ?? 'Failed to start this workflow.';
+      runStartTimedOut.value = true;
+      return;
     }
+
+    // Hand it to the app-wide checker so the outcome is caught after leaving this screen.
+    // The name has to be captured here — at completion there is only the run id.
+    void trackWorkflow({
+      wfId,
+      label: workflow.value?.name || wfId,
+      action: 'run',
+    });
+
+    await waitForNewRun(wfId);
   }
 
   // Ensure polling does not linger after leaving the screen
@@ -573,6 +660,10 @@ export function useWorkflowRunViewerModel() {
     cloneForEdit,
     progress,
     runStarting,
+    runStartTimedOut,
+    runStartError,
+    keepWaitingForRun,
+    stopWaitingForRun,
     runWorkflow,
     stopPolling,
   };

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -57,6 +57,10 @@ const {
   progress,
   isPolling,
   runStarting,
+  runStartTimedOut,
+  runStartError,
+  keepWaitingForRun,
+  stopWaitingForRun,
   cloning,
   loadError,
   logText,
@@ -678,12 +682,71 @@ async function onRunChange(runId: string) {
           class="run-viewer__starting"
           data-testid="workflow-run-starting"
         >
-          <span class="run-viewer__running-spinner" aria-hidden="true" />
-          <p class="run-viewer__starting-title">Preparing run data…</p>
-          <p class="run-viewer__starting-hint">
-            The run has been requested. Waiting until it appears in the run
-            history — the graph below still shows the previous run until then.
-          </p>
+          <!--
+            Still waiting. Nothing is wrong yet, so this says only what it is waiting for.
+          -->
+          <template v-if="!runStartTimedOut">
+            <span class="run-viewer__running-spinner" aria-hidden="true" />
+            <p class="run-viewer__starting-title">Preparing run data…</p>
+            <p class="run-viewer__starting-hint">
+              The run has been requested. Waiting until it appears in the run
+              history — the graph below still shows the previous run until then.
+            </p>
+          </template>
+
+          <!--
+            The wait ran out. **Do not say the run failed** — the engine took the request and
+            may be running it right now; what we know is that we could not confirm it. Saying
+            nothing and quietly redrawing (what this used to do) is worse: the screen comes
+            back looking normal while the run is nowhere to be seen.
+          -->
+          <template v-else>
+            <p
+              class="run-viewer__starting-title run-viewer__starting-title--warn"
+              data-testid="workflow-run-start-timeout"
+            >
+              The new run still cannot be found
+            </p>
+            <p class="run-viewer__starting-hint">
+              It has been a while, and the run you started has still not
+              appeared in the run history. Something may be wrong with the
+              server. What would you like to do?
+            </p>
+            <p
+              v-if="runStartError"
+              class="run-viewer__starting-error"
+              data-testid="workflow-run-start-error"
+            >
+              {{ runStartError }}
+            </p>
+            <div class="run-viewer__starting-actions">
+              <p-button
+                data-testid="workflow-run-start-keep-waiting"
+                size="sm"
+                style-type="primary"
+                @click="keepWaitingForRun"
+              >
+                Keep waiting
+              </p-button>
+              <p-button
+                data-testid="workflow-run-start-stop-waiting"
+                size="sm"
+                style-type="tertiary"
+                @click="stopWaitingForRun"
+              >
+                Cancel
+              </p-button>
+            </div>
+            <!--
+              "Cancel" is about *this wait*, not about the run. Nothing here stops a run, and a
+              user who reads it the other way would walk away believing they had stopped it.
+            -->
+            <p class="run-viewer__starting-hint">
+              Cancelling stops waiting only — it does not stop the run, which
+              may still be going. The screen is refreshed so it shows where
+              things actually stand.
+            </p>
+          </template>
         </div>
 
         <!--
@@ -1374,7 +1437,27 @@ async function onRunChange(runId: string) {
 .run-viewer__starting-hint {
   font-size: 0.75rem;
   color: #6b6e78;
-  max-width: 20rem;
+  max-width: 22rem;
+}
+
+.run-viewer__starting-title--warn {
+  color: #8a5a17;
+}
+
+.run-viewer__starting-error {
+  max-width: 22rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  background: #fdf3f3;
+  color: #b93c3c;
+  font-size: 0.75rem;
+  word-break: break-all;
+}
+
+.run-viewer__starting-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.25rem 0;
 }
 
 .run-viewer__graph {


### PR DESCRIPTION
## Problem

After a run is requested the screen waits for it to show up in the run history. If thirty seconds passed without it appearing, the screen reopened itself. That is wrong twice over: it says nothing, so the view comes back looking perfectly normal while the run the user just asked for is nowhere to be seen; and it throws away the run they were looking at.

## What changed

The wait now ends by telling the truth. It says the run still cannot be found and that something may be wrong with the server, then asks whether to keep waiting or to cancel. If the request itself was refused, that error is shown straight away — there is nothing to wait for. If the run-history query was still failing when the wait ran out, the reason is shown alongside.

It does not say the run failed. The engine accepted the request and may be running it right now; all we know is that we could not confirm it, so that is all the screen claims.

Cancel is about the wait, not the run. Nothing here stops a run, and a user reading it the other way would walk away believing they had stopped it, so the screen states that plainly. Cancelling refreshes the screen once, because after a wait that long the view can be out of step with reality — with no history at all it falls back to the un-run state, and after a re-run the latest run is picked up again.

A single failed query is not reported. Right after a workflow is created the engine answers 404 until it has registered the DAG, so treating one failure as an error would cry wolf on a normal first run. Only a failure that is still happening when the wait ends is worth a reason.

## Verification

The run-history query was made to fail so the timeout path could actually be walked, and the screen was checked at each step: the message and the reason appear with both choices, the run being viewed is left alone, keeping the wait recovers once the query does, and cancelling refreshes. In that last case the refresh brought back a run that had in fact started — going quiet would have left the user unaware it existed.

Follows on from #102.