### PR TITLE
fix(workload): make Stop work on a running load test

### DIFF
--- a/front/src/entities/vm/api/api.ts
+++ b/front/src/entities/vm/api/api.ts
@@ -54,19 +54,28 @@ export function useRunLoadTest(requestPayload: IRunLoadTestRequest | null) {
   >(RUN_LOAD_TEST, requestBodyWrapper);
 }
 
-// Stop a running load test (StopLoadTest). Identified by loadTestKey.
-export function useStopLoadTest(loadTestKey: string | null) {
+// Stop a running load test (StopLoadTest).
+//
+// cm-ant identifies the run by its key *and* by the node it belongs to, and rejects the request
+// before looking anything up unless nsId, infraId and nodeId are all present. Sending the key
+// alone always comes back 400 "load test stop info is not correct."
+export interface IStopLoadTestRequest {
+  loadTestKey: string;
+  nsId: string;
+  infraId: string;
+  nodeId: string;
+}
+
+export function useStopLoadTest(request: IStopLoadTestRequest | null) {
   const requestBodyWrapper: Required<
-    Pick<RequestBodyWrapper<{ loadTestKey: string } | null>, 'request'>
+    Pick<RequestBodyWrapper<IStopLoadTestRequest | null>, 'request'>
   > = {
-    request: loadTestKey ? { loadTestKey } : null,
+    request,
   };
 
   return useAxiosPost<
     IAxiosResponse<unknown>,
-    Required<
-      Pick<RequestBodyWrapper<{ loadTestKey: string } | null>, 'request'>
-    >
+    Required<Pick<RequestBodyWrapper<IStopLoadTestRequest | null>, 'request'>>
   >(STOP_LOAD_TEST, requestBodyWrapper);
 }
 

--- a/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
+++ b/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
@@ -49,6 +49,26 @@ function handleOpenLoadconfig() {
 const isLoadTestRunning = computed(() =>
   ['Running', 'Collecting results'].includes(props.loadTestStatus ?? ''),
 );
+
+// Stopping a run means killing the JMeter process on the load generator, so there is nothing to
+// stop until the generator is installed — cm-ant answers a stop request before that point with
+// "load install info: record not found". The phases before it (pre-check, generator install) are
+// short and end on their own, so the button waits for the generator instead of failing.
+//
+// An older cm-ant reports no steps at all; there is nothing to base the decision on, so the
+// button stays available rather than being permanently disabled.
+const canStopLoadTest = computed(() => {
+  const steps = props.loadTestSteps ?? [];
+  if (!steps.length) return true;
+  return steps.some(s => s.name === 'generator_install' && s.status === 'ok');
+});
+
+// Same guard as Load Config: mirinae's disabled is a class only and the click still reaches the
+// element (DESIGN-MIRINAE §1.6), so the handler has to hold the rule too.
+function handleStopLoadTest() {
+  if (!canStopLoadTest.value) return;
+  emit('stopLoadTest');
+}
 const hasLoadTest = computed(() => !!props.loadTestStatus);
 const isLoadTestFailed = computed(() => props.loadTestStatus === 'Failed');
 // Results (charts / aggregation) show only on success. Nothing is fetched while running/failed.
@@ -97,7 +117,13 @@ const isLoadTestCompleted = computed(() => props.loadTestStatus === 'Completed')
           data-testid="vm-load-stop"
           style-type="negative-secondary"
           icon-left="ic_close"
-          @click="emit('stopLoadTest')"
+          :disabled="!canStopLoadTest"
+          :title="
+            canStopLoadTest
+              ? undefined
+              : 'Available once the load generator is installed'
+          "
+          @click="handleStopLoadTest"
         >
           Stop
         </p-button>

--- a/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
+++ b/front/src/widgets/workload/vm/vmEvaluatePerf/ui/VmEvaluatePerf.vue
@@ -50,17 +50,19 @@ const isLoadTestRunning = computed(() =>
   ['Running', 'Collecting results'].includes(props.loadTestStatus ?? ''),
 );
 
-// Stopping a run means killing the JMeter process on the load generator, so there is nothing to
-// stop until the generator is installed — cm-ant answers a stop request before that point with
-// "load install info: record not found". The phases before it (pre-check, generator install) are
-// short and end on their own, so the button waits for the generator instead of failing.
+// Stopping a run kills the JMeter process on the load generator, so it only means anything while
+// JMeter is actually running. Asked earlier, cm-ant fails in two different ways and both reached
+// the screen as a bare 400: before the generator exists it cannot find the install record, and
+// once it exists but the load has not started the kill command matches no process and comes back
+// with a non-zero exit. The phases before the load run — pre-check, generator install, agent
+// install, test plan — are short and end on their own, so the button waits for the load run.
 //
 // An older cm-ant reports no steps at all; there is nothing to base the decision on, so the
 // button stays available rather than being permanently disabled.
 const canStopLoadTest = computed(() => {
   const steps = props.loadTestSteps ?? [];
   if (!steps.length) return true;
-  return steps.some(s => s.name === 'generator_install' && s.status === 'ok');
+  return steps.some(s => s.name === 'jmeter_run' && s.status === 'running');
 });
 
 // Same guard as Load Config: mirinae's disabled is a class only and the click still reaches the
@@ -121,7 +123,7 @@ const isLoadTestCompleted = computed(() => props.loadTestStatus === 'Completed')
           :title="
             canStopLoadTest
               ? undefined
-              : 'Available once the load generator is installed'
+              : 'Available once the load run has started'
           "
           @click="handleStopLoadTest"
         >

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -154,9 +154,19 @@ async function handleReRun() {
 }
 function handleStopLoadTest() {
   const key = currentLoadTestKey.value;
-  if (!key) return;
+  const nodeId = selectedVm.value?.id;
+  if (!key || !nodeId) return;
+  // cm-ant needs the node the run belongs to, not just the key — without nsId/infraId/nodeId it
+  // rejects the request with 400 before it looks the run up.
   resStopLoadTest
-    .execute({ request: { loadTestKey: key } })
+    .execute({
+      request: {
+        loadTestKey: key,
+        nsId: props.nsId,
+        infraId: props.mciId,
+        nodeId,
+      },
+    })
     .then(() => setVmLoadTestResult())
     .catch(e => showErrorMessage('error', e.errorMsg?.value ?? 'Stop failed'));
 }


### PR DESCRIPTION
## What was wrong

Pressing **Stop** on a running load test always came back `400 Bad Request` and the run kept going. The console showed only the bare status text, so it looked like one problem.

It was three, and which one you got depended on *when* you pressed the button. We ran a load test on a deployment and pressed Stop at each phase.

| When Stop was pressed | Response from cm-ant | Why |
|---|---|---|
| any time | `load test stop info is not correct.` | the console sent only `loadTestKey`; cm-ant also requires `nsId`, `infraId` and `nodeId` |
| before the generator exists | `retrieve load install info: record not found` | there is no generator record to look up yet |
| generator ready, load not started | `command execution failed …: Process exited with status 2` | JMeter is not up, so the kill command matches no process |

The root of the last two is that stopping, on the server side, is a single action: run

```
kill -15 $(ps -ef | grep -E '/bin/ApacheJMeter\.jar.*<key>' | awk '{print $2}')
```

on the load generator. It only means anything once JMeter is actually running. `GeneratorInstallInfoId` is filled in only after the pre-check and the generator install finish, and until the load run starts there is no process to match — the kill then exits non-zero and the failure surfaces as a 400 **while the run carries on to completion**. Pressing the button did nothing at all.

## What changed

Three commits, all in the console.

1. **Send the node the run belongs to.** `useStopLoadTest` now carries `nsId`, `infraId` and `nodeId` next to `loadTestKey` — values the screen already holds (`props.nsId`, `props.mciId`, `selectedVm.id`). Without them the request is rejected before cm-ant looks anything up.

2. **Offer Stop only while the load run is in progress.** The decision is one condition — the `jmeter_run` phase reports `running`. The phases before it (pre-check, generator install, agent install, test plan) are short and end on their own, so instead of leaving a button that is guaranteed to fail, it is disabled with `title="Available once the load run has started"`.

3. **Guard the handler, not just the button.** The UI library renders `disabled` as a class only and leaves `pointer-events` alive, so the click still reaches the element and the standard `disabled` attribute is never emitted. A visual-only guard would not hold, so `handleStopLoadTest` re-checks the same condition before emitting.

An older cm-ant reports no `steps[]` at all. With nothing to base the decision on, the button stays available rather than being permanently disabled.

**The server is unchanged.** Cancelling a run whose load generator does not exist yet has no meaning, and the console already knows exactly which phase it is in.

## Verification

Run on a deployment with a real load test — not injected state.

| Elapsed | Phase on screen | Stop |
|---:|---|---|
| t+0s | Running | disabled |
| t+5s | Load generator install | disabled |
| t+15s | Metric agent install | disabled |
| **t+20s** | **Load run** | **enabled** |

Pressing it during the load run: the request carried all four fields, cm-ant answered **200** `Successfully stop load generator`, and the run ended **within 5 seconds** — the progress panel and the Stop button disappeared and polling stopped. Six checks in total, all passing, including a comparison against the previous build (400 at every phase, run completing regardless).

The enabled/disabled state was judged from the element's class rather than `isEnabled()`, since the library never sets the standard attribute and the standard API would answer "enabled" in both cases.

## Known limits, and what changes later

This narrows *when* the button can be pressed; it does not complete cancellation. Two things remain visible to users, both on the server side:

- **A stopped run is recorded as failed.** The execution status values are `on_processing`, `on_fetching`, `successed` and `test_failed` — there is no "stopped", so a run the user cancelled is indistinguishable from one that failed on its own. The failure reason reads `Process exited with status 143`, which is the SIGTERM we sent.
- **The kill does not end the run.** Only JMeter dies; the flow continues into result collection and records those steps as successful. On screen that shows as a failed load-run phase with successful steps beneath it.

Once cm-ant grows per-phase cancellation — cancelling the work in progress and closing the run out properly, with a status that says "stopped" — **Stop can be offered during the earlier phases as well, and this display will change accordingly.** The condition in this change is a single computed value, so relaxing it is a small edit.