### PR TITLE
fix(workload): bring the progress bar cap down to the step list width

### DIFF
--- a/front/src/widgets/workload/vm/loadTestProgress/ui/LoadTestProgress.vue
+++ b/front/src/widgets/workload/vm/loadTestProgress/ui/LoadTestProgress.vue
@@ -534,7 +534,7 @@ const hasSteps = computed(() => steps.value.length > 0);
    fixed width, so a narrower browser shrinks the whole row with the panel. */
 .lt-bar-row.is-full {
   width: 100%;
-  max-width: 640px;
+  max-width: 480px;
 }
 
 .lt-bar {


### PR DESCRIPTION
Follow-up to #104. The cap that landed there is 640 px, which is still wider than the step lines it was meant to match — so the percentage and the polling spinner still sit past the end of the text the eye is reading.

Measured on a 1920 px browser while a load test runs:

| | width |
|---|---:|
| step text below the bar (longest line) | ~405 px |
| bar row at the 640 px cap | 640 px |
| bar row at 480 px | 480 px — bar 418 px, percentage and spinner the rest |

At 480 px the row ends just past the step text instead of well beyond it, which is what the change set out to do: keep *which step is running* and *is it still moving* inside one glance.

Nothing else about the rule changes. It is still a cap rather than a fixed width, so a narrower panel shrinks the whole row along with it, and only the full panel is affected — the compact cell in the Information tab keeps filling its column.

Verified on a deployment across browser widths from 500 to 1920 px: the row stops at the cap on wide screens, shrinks with the panel below it, and no horizontal scrollbar appears at any width. Below the cap the measurements are unchanged.