### PR TITLE
fix(models): send Minimum Match Rate as the single value the server expects

### DIFF
--- a/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
+++ b/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
@@ -4,6 +4,7 @@ import {
   PIconModal,
   PToolboxTable,
   PSelectDropdown,
+  PTooltip,
 } from '@cloudforet-test/mirinae';
 import { CreateForm } from '@/widgets/layout';
 import { TargetModelNameSave } from '@/features/models';
@@ -38,11 +39,13 @@ const auth = useAuth();
 
 // Helper to validate VM data
 function isValidVmData(vm: any): boolean {
-  return vm && 
-         vm.specId && 
-         vm.specId.trim() !== '' && 
-         vm.imageId && 
-         vm.imageId.trim() !== '';
+  return (
+    vm &&
+    vm.specId &&
+    vm.specId.trim() !== '' &&
+    vm.imageId &&
+    vm.imageId.trim() !== ''
+  );
 }
 
 // Helper to render the "empty" text in red
@@ -50,7 +53,10 @@ function formatEmptyValue(value: string): string {
   if (!value) return '';
 
   // Turn the "empty" string red (replace on a whole-word basis)
-  return value.replace(/\bempty\b/g, '<span style="color: red; font-weight: bold;">empty</span>');
+  return value.replace(
+    /\bempty\b/g,
+    '<span style="color: red; font-weight: bold;">empty</span>',
+  );
 }
 const recommendInfraModel = useRecommendedInfraModel();
 
@@ -115,8 +121,97 @@ const targetSourceModel = computed(() =>
 
 // Query parameter inputs
 const candidateLimit = ref<number>(3);
-const minimumMatchRateMin = ref<number | null>(null);
-const minimumMatchRateMax = ref<number>(100);  // default 100
+
+/*
+ * Minimum Match Rate — cm-beetle takes ONE number (query `minMatchRate`, 0-100, default 90.0).
+ * There is no "max" counterpart, so this is a single field: a range string such as "90-100"
+ * fails ParseFloat on the server, which then silently falls back to 90.0 (BAR-1634).
+ *
+ * Empty means "send nothing" so the server default applies. The slider therefore rests at
+ * MATCH_RATE_DEFAULT while the field is empty, and the hint under the field says which one is in effect.
+ */
+const MATCH_RATE_MIN = 0;
+const MATCH_RATE_MAX = 100;
+const MATCH_RATE_DEFAULT = 90;
+
+/** Raw text of the number field. '' means "not specified" (parameter is omitted). */
+const matchRateInput = ref<string>('');
+
+/** Parsed value, or null when the field is empty / unparsable. */
+const matchRate = computed<number | null>(() => {
+  const raw = matchRateInput.value.trim();
+  if (raw === '') return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+});
+
+/*
+ * The hint under the row appears while either control holds focus, and goes away when focus
+ * leaves. It is tied to focus rather than to "a value was entered", because the moment a user
+ * needs to know what this field is, is *before* touching it — a hint that only shows up after
+ * you change the value explains it too late.
+ *
+ * Focus (not hover) drives it on purpose: hovering across the row on the way somewhere else
+ * would flash the line, and clicking or dragging either control focuses it anyway.
+ */
+const matchRateFocused = ref(false);
+
+function handleMatchRateFocusOut(event: FocusEvent) {
+  const wrapper = event.currentTarget as HTMLElement;
+  const next = event.relatedTarget as Node | null;
+  // Moving between the slider and the number field stays "focused" — only leaving the pair counts.
+  if (next && wrapper.contains(next)) return;
+  matchRateFocused.value = false;
+}
+
+/** Where the slider sits: the entered value, or the server default while the field is empty. */
+const matchRateSliderValue = computed<number>(
+  () => matchRate.value ?? MATCH_RATE_DEFAULT,
+);
+
+const matchRateHelp = `<strong>Minimum Match Rate</strong><br/>
+The threshold that <em>classifies</em> the recommended candidates (0-100%, default ${MATCH_RATE_DEFAULT}%).<br/><br/>
+&#8226; A VM counts as <b>matched</b> only when its CPU, memory and OS image all reach this rate.<br/>
+&#8226; A candidate is <b>highly-matched</b> only when <b>every</b> VM is matched; otherwise it is <b>partially-matched</b>.<br/>
+&#8226; This does <b>not</b> filter the results &mdash; both kinds stay in the list. Use <b>Candidate Limit</b> to change how many candidates come back.<br/>
+&#8226; Leave it empty to let the server apply its default (${MATCH_RATE_DEFAULT}%).`;
+
+function clampMatchRate(value: number): number {
+  return Math.min(MATCH_RATE_MAX, Math.max(MATCH_RATE_MIN, value));
+}
+
+/*
+ * Keep the field inside 0-100 while it is being typed. Out-of-range values are not merely
+ * ugly: cm-beetle answers them by reverting to 90.0 without telling anyone, so a user who
+ * typed 150 would silently get the default. The DOM value is written back explicitly because
+ * clamping can leave the bound string unchanged (150 -> 100, then 1500 -> 100), and Vue skips
+ * the DOM update when the value it holds did not change.
+ */
+function handleMatchRateInput(event: Event) {
+  const el = event.target as HTMLInputElement;
+  const raw = el.value.trim();
+
+  if (raw === '') {
+    matchRateInput.value = '';
+    return;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    // Not a number yet (e.g. a lone '-'); drop it rather than sending garbage.
+    matchRateInput.value = '';
+    el.value = '';
+    return;
+  }
+
+  matchRateInput.value = String(clampMatchRate(parsed));
+  if (el.value !== matchRateInput.value) el.value = matchRateInput.value;
+}
+
+function handleMatchRateSlider(event: Event) {
+  const el = event.target as HTMLInputElement;
+  matchRateInput.value = String(clampMatchRate(Number(el.value)));
+}
 
 const modalState = reactive({
   targetModal: false,
@@ -132,16 +227,10 @@ async function getRecommendModelList() {
   recommendInfraModel.initToolBoxTableModel();
 
   try {
-    // Assemble the minimumMatchRate parameter
-    let minimumMatchRateParam: string | number | null = null;
-    if (minimumMatchRateMin.value !== null && minimumMatchRateMax.value !== null) {
-      minimumMatchRateParam = `${minimumMatchRateMin.value}-${minimumMatchRateMax.value}`;
-    } else if (minimumMatchRateMin.value !== null) {
-      minimumMatchRateParam = minimumMatchRateMin.value;
-    } else if (minimumMatchRateMax.value !== null) {
-      minimumMatchRateParam = minimumMatchRateMax.value;
-    }
-    
+    // Send a single number, or nothing at all when the field is empty (server default applies).
+    const minimumMatchRateParam =
+      matchRate.value === null ? null : clampMatchRate(matchRate.value);
+
     // Call the Candidates API (fetch multiple candidates)
     const getRecommendCandidates = useGetRecommendModelCandidates(
       targetSourceModel.value?.onpremiseInfraModel || null,
@@ -152,75 +241,105 @@ async function getRecommendModelList() {
     );
 
     const res = await getRecommendCandidates.execute();
-    
+
     console.log('=== Recommend Candidates Response ===');
     console.log('Type of res:', typeof res);
     console.log('Keys of res:', Object.keys(res));
     console.log('res.data type:', typeof res.data);
     console.log('res.data keys:', res.data ? Object.keys(res.data) : 'null');
-    
+
     // API response shape: { responseData: { data: [...] } }
-    if (res.data?.responseData?.data && Array.isArray(res.data.responseData.data)) {
+    if (
+      res.data?.responseData?.data &&
+      Array.isArray(res.data.responseData.data)
+    ) {
       const candidates = res.data.responseData.data;
       console.log(`Found ${candidates.length} candidate(s)`);
-      
+
       // Compute cost and clean up data for each candidate
       const processedCandidates = candidates.map((candidate, index) => {
-        console.log(`Processing candidate ${index + 1}:`, JSON.stringify(candidate, null, 2));
-        
+        console.log(
+          `Processing candidate ${index + 1}:`,
+          JSON.stringify(candidate, null, 2),
+        );
+
         // Validate and clean up the API response data
         if (candidate.targetInfra?.nodeGroups) {
           const originalLength = candidate.targetInfra.nodeGroups.length;
-          
+
           // Log invalid data
-          const invalidVms = candidate.targetInfra.nodeGroups.filter(vm => 
-            !vm || !vm.specId || vm.specId.trim() === '' || !vm.imageId || vm.imageId.trim() === ''
+          const invalidVms = candidate.targetInfra.nodeGroups.filter(
+            vm =>
+              !vm ||
+              !vm.specId ||
+              vm.specId.trim() === '' ||
+              !vm.imageId ||
+              vm.imageId.trim() === '',
           );
-          
+
           if (invalidVms.length > 0) {
-            console.warn(`Candidate ${index + 1}: Found ${invalidVms.length} invalid VMs`);
+            console.warn(
+              `Candidate ${index + 1}: Found ${invalidVms.length} invalid VMs`,
+            );
           }
-          
+
           // Replace empty fields of invalid data with "empty"
-          candidate.targetInfra.nodeGroups = candidate.targetInfra.nodeGroups.map(vm => {
-            const updatedVm = { ...vm };
-            if (!vm.specId || vm.specId.trim() === '') {
-              updatedVm.specId = 'empty';
-            }
-            if (!vm.imageId || vm.imageId.trim() === '') {
-              updatedVm.imageId = 'empty';
-            }
-            return updatedVm;
-          });
+          candidate.targetInfra.nodeGroups =
+            candidate.targetInfra.nodeGroups.map(vm => {
+              const updatedVm = { ...vm };
+              if (!vm.specId || vm.specId.trim() === '') {
+                updatedVm.specId = 'empty';
+              }
+              if (!vm.imageId || vm.imageId.trim() === '') {
+                updatedVm.imageId = 'empty';
+              }
+              return updatedVm;
+            });
         }
 
         // Cost calculation (based on targetSpecList)
         try {
           let totalCostPerHour = 0;
           let currency = '';
-          let skippedVms: Array<{ vmName: string; specId: string; costPerHour: number }> = [];
-          
+          let skippedVms: Array<{
+            vmName: string;
+            specId: string;
+            costPerHour: number;
+          }> = [];
+
           candidate.targetInfra.nodeGroups?.forEach(vm => {
-            const matchingSpec = candidate.targetSpecList?.find(spec => spec.id === vm.specId);
-            if (matchingSpec && matchingSpec.costPerHour !== undefined && matchingSpec.costPerHour !== null) {
+            const matchingSpec = candidate.targetSpecList?.find(
+              spec => spec.id === vm.specId,
+            );
+            if (
+              matchingSpec &&
+              matchingSpec.costPerHour !== undefined &&
+              matchingSpec.costPerHour !== null
+            ) {
               if (matchingSpec.costPerHour < 0) {
                 skippedVms.push({
                   vmName: vm.name,
                   specId: vm.specId,
-                  costPerHour: matchingSpec.costPerHour
+                  costPerHour: matchingSpec.costPerHour,
                 });
-                console.warn(`Skipping VM with negative cost: ${vm.name} (${vm.specId})`);
+                console.warn(
+                  `Skipping VM with negative cost: ${vm.name} (${vm.specId})`,
+                );
               } else {
                 totalCostPerHour += matchingSpec.costPerHour;
                 currency = matchingSpec.currency || 'USD';
               }
             } else {
-              console.warn(`No cost information found for VM: ${vm.name} (${vm.specId})`);
+              console.warn(
+                `No cost information found for VM: ${vm.name} (${vm.specId})`,
+              );
             }
           });
-          
+
           if (skippedVms.length > 0) {
-            console.warn(`Candidate ${index + 1}: Skipped ${skippedVms.length} VMs due to invalid cost`);
+            console.warn(
+              `Candidate ${index + 1}: Skipped ${skippedVms.length} VMs due to invalid cost`,
+            );
           }
 
           const totalCostPerMonth = totalCostPerHour * 24 * 30;
@@ -229,31 +348,42 @@ async function getRecommendModelList() {
             ...candidate,
             estimateResponse: {
               result: {
-                esimateCostSpecResults: [{
-                  estimateForecastCostSpecDetailResults: [{
-                    calculatedMonthlyPrice: totalCostPerMonth,
-                    calculatedHourlyPrice: totalCostPerHour,
-                    currency: currency
-                  }]
-                }]
-              }
-            }
+                esimateCostSpecResults: [
+                  {
+                    estimateForecastCostSpecDetailResults: [
+                      {
+                        calculatedMonthlyPrice: totalCostPerMonth,
+                        calculatedHourlyPrice: totalCostPerHour,
+                        currency: currency,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
           };
         } catch (e) {
-          console.error(`Error calculating cost for candidate ${index + 1}:`, e);
+          console.error(
+            `Error calculating cost for candidate ${index + 1}:`,
+            e,
+          );
           return {
             ...candidate,
             estimateResponse: {
               result: {
-                esimateCostSpecResults: [{
-                  estimateForecastCostSpecDetailResults: [{
-                    calculatedMonthlyPrice: 0,
-                    calculatedHourlyPrice: 0,
-                    currency: 'USD'
-                  }]
-                }]
-              }
-            }
+                esimateCostSpecResults: [
+                  {
+                    estimateForecastCostSpecDetailResults: [
+                      {
+                        calculatedMonthlyPrice: 0,
+                        calculatedHourlyPrice: 0,
+                        currency: 'USD',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
           };
         }
       });
@@ -265,12 +395,13 @@ async function getRecommendModelList() {
       try {
         const tableItems = processedCandidates.map((candidate, index) => {
           console.log(`Organizing table item ${index + 1}:`, candidate);
-          const item = recommendInfraModel.organizeRecommendedModelTableItem(candidate);
+          const item =
+            recommendInfraModel.organizeRecommendedModelTableItem(candidate);
           item.index = index + 1; // add the sequence number
           console.log(`Organized item ${index + 1}:`, item);
           return item;
         });
-        
+
         console.log('Setting table items:', tableItems);
         recommendInfraModel.tableModel.tableState.items = tableItems;
         console.log('Table items set successfully');
@@ -278,7 +409,6 @@ async function getRecommendModelList() {
         console.error('Error organizing table items:', tableError);
         throw tableError;
       }
-      
     } else {
       // No matching candidate is a normal outcome — it happens whenever the spec filter is narrow.
       // Leave the table empty and just inform. A red error here makes a 200 OK look like a failure.
@@ -316,16 +446,22 @@ function handleSave(e: { name: string; description: string }) {
   try {
     // selectIndex is stored as an array ([0], [1], [2], ...), so extract the first element
     const selectIndex = recommendInfraModel.tableModel.tableState.selectIndex;
-    const rowIndex = Array.isArray(selectIndex) ? selectIndex[0] : selectIndex as number;
+    const rowIndex = Array.isArray(selectIndex)
+      ? selectIndex[0]
+      : (selectIndex as number);
 
-    const displayItem = recommendInfraModel.tableModel.tableState.displayItems[rowIndex];
+    const displayItem =
+      recommendInfraModel.tableModel.tableState.displayItems[rowIndex];
     if (!displayItem) {
       throw new Error(`No display item found at index ${rowIndex}`);
     }
 
     let selectedModel: IRecommendModelResponse = displayItem.originalData;
 
-    if (!selectedModel?.targetInfra?.nodeGroups || selectedModel.targetInfra.nodeGroups.length === 0) {
+    if (
+      !selectedModel?.targetInfra?.nodeGroups ||
+      selectedModel.targetInfra.nodeGroups.length === 0
+    ) {
       throw new Error('Selected model has no VM nodeGroups');
     }
 
@@ -337,7 +473,7 @@ function handleSave(e: { name: string; description: string }) {
 
     // Use the existing targetInfra as-is (no processing)
     const modifiedTargetVmInfra = {
-      ...selectedModel.targetInfra
+      ...selectedModel.targetInfra,
       // Keep nodeGroups exactly as the original
     };
 
@@ -350,14 +486,18 @@ function handleSave(e: { name: string; description: string }) {
       targetVNet: selectedModel.targetVNet || {},
       targetInfra: modifiedTargetVmInfra, // use the unprocessed targetInfra
       targetOsImageList: selectedModel.targetOsImageList || [],
-      targetSpecList: selectedModel.targetSpecList || []
+      targetSpecList: selectedModel.targetSpecList || [],
     };
 
     // Use defaults if specId is an empty string or has no +
     let csp = 'default-csp';
     let region = 'default-region';
-    
-    if (selectedVm.specId && selectedVm.specId !== 'empty' && selectedVm.specId.includes('+')) {
+
+    if (
+      selectedVm.specId &&
+      selectedVm.specId !== 'empty' &&
+      selectedVm.specId.includes('+')
+    ) {
       const commonSpecSplitData = selectedVm.specId.split('+');
       csp = commonSpecSplitData[0];
       region = commonSpecSplitData[1];
@@ -404,21 +544,29 @@ function handleSave(e: { name: string; description: string }) {
     >
       <template #add-info>
         <div class="flex gap-4 flex-col w-full">
-          <!-- Place the Provider, Region and Search buttons on the same line -->
-          <section class="select-service-box flex w-full items-center gap-4">
-            <p class="text-label-lg font-bold">Provider</p>
-            <p-select-dropdown
-              data-testid="recommend-provider-select"
-              :menu="provider.menu"
-              :loading="provider.loading"
-              @update:visible-menu="handleProviderMenuClick"
-              @select="
-                e => {
-                  provider.selected = e;
-                  handleRegionMenuClick(true);
-                }
-              "
-            ></p-select-dropdown>
+          <!--
+            Place the Provider, Region and Search buttons on the same line.
+            Provider sits in the same fixed-width cell as Candidate Limit on the row below, so
+            "Region" and "Minimum Match Rate (%)" start at the same x. Aligning to whatever width
+            the Provider dropdown happens to take does not work — its width follows the selected
+            value, so the column shifts between runs. (BAR-1634)
+          -->
+          <section class="select-service-box params-section__row w-full">
+            <div class="param-group">
+              <p class="text-label-lg font-bold">Provider</p>
+              <p-select-dropdown
+                data-testid="recommend-provider-select"
+                :menu="provider.menu"
+                :loading="provider.loading"
+                @update:visible-menu="handleProviderMenuClick"
+                @select="
+                  e => {
+                    provider.selected = e;
+                    handleRegionMenuClick(true);
+                  }
+                "
+              />
+            </div>
             <p class="text-label-lg font-bold">Region</p>
             <p-select-dropdown
               data-testid="recommend-region-select"
@@ -431,10 +579,10 @@ function handleSave(e: { name: string; description: string }) {
                   region.selected = e;
                 }
               "
-            ></p-select-dropdown>
-            
+            />
+
             <!-- Push the Search button to the far right -->
-            <div class="flex-grow"></div>
+            <div class="flex-grow" />
             <p-button
               data-testid="recommend-search"
               :disabled="!provider.selected || !region.selected"
@@ -443,47 +591,119 @@ function handleSave(e: { name: string; description: string }) {
               Search
             </p-button>
           </section>
-          <!-- Lay out the Query Parameters horizontally -->
-          <section class="select-service-box flex w-full items-center gap-4">
-            <!-- Candidate Limit with tooltip -->
-            <p class="text-label-lg font-bold" title="Maximum number of recommended infrastructures to return (default: 3)">Candidate Limit</p>
-            <input
-              v-model.number="candidateLimit"
-              data-testid="recommend-candidate-limit"
-              type="number"
-              :min="1"
-              :max="10"
-              class="p-2 border rounded"
-              style="width: 80px"
-              placeholder="3"
-              title="Maximum number of recommended infrastructures to return (default: 3)"
-            />
-            
-            <!-- Minimum Match Rate with tooltip -->
-            <p class="text-label-lg font-bold" title="Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)">Minimum Match Rate(%)</p>
-            <input
-              v-model.number="minimumMatchRateMin"
-              type="number"
-              :min="1"
-              :max="100"
-              step="1"
-              class="p-2 border rounded"
-              style="width: 80px"
-              placeholder="Min"
-              title="Minimum match rate threshold for highly-matched classification (default: 90.0, range: 0-100)"
-            />
-            <span class="text-label-lg">~</span>
-            <input
-              v-model.number="minimumMatchRateMax"
-              type="number"
-              :min="1"
-              :max="100"
-              step="1"
-              class="p-2 border rounded"
-              style="width: 80px"
-              placeholder="Max"
-              title="Maximum match rate threshold for highly-matched classification (default: 100, range: 0-100)"
-            />
+          <!--
+            Query parameters — one row, with the Minimum Match Rate hint on a full-width line
+            underneath. Both are kept compact so the row does not wrap while the modal still has
+            horizontal room to spare.
+          -->
+          <section class="params-section">
+            <div class="params-section__row">
+              <!--
+                Candidate Limit uses the same fixed-width cell as Provider above, so both rows
+                start their second label at the same x instead of reading as a crooked column.
+                A scenario asserts the alignment, so the width cannot drift unnoticed.
+              -->
+              <div class="param-group">
+                <p
+                  class="text-label-lg font-bold"
+                  title="Maximum number of recommended infrastructures to return (default: 3)"
+                >
+                  Candidate Limit
+                </p>
+                <input
+                  v-model.number="candidateLimit"
+                  data-testid="recommend-candidate-limit"
+                  type="number"
+                  :min="1"
+                  :max="10"
+                  class="param-input"
+                  placeholder="3"
+                  title="Maximum number of recommended infrastructures to return (default: 3)"
+                />
+              </div>
+
+              <!--
+                Minimum Match Rate — one value only. cm-beetle exposes a single `minMatchRate`
+                (0-100, default 90) and answers anything it cannot parse by silently using 90,
+                so the screen must not invent a range. The '?' badge sits at the label's
+                bottom-right and opens the detailed explanation on hover/focus. (BAR-1634)
+              -->
+              <span class="match-rate-label">
+                <span class="text-label-lg font-bold"
+                  >Minimum Match Rate (%)</span
+                >
+                <p-tooltip
+                  :contents="matchRateHelp"
+                  position="bottom"
+                  :options="{ classes: ['p-tooltip', 'match-rate-tooltip'] }"
+                >
+                  <span
+                    class="match-rate-label__help"
+                    data-testid="recommend-match-rate-help"
+                    tabindex="0"
+                    aria-label="What Minimum Match Rate means"
+                    >?</span
+                  >
+                </p-tooltip>
+              </span>
+              <!--
+                Focus on either control shows the hint; leaving the pair hides it. Both are wrapped
+                so that moving focus between the slider and the number field does not count as
+                leaving.
+              -->
+              <span
+                class="match-rate-controls"
+                @focusin="matchRateFocused = true"
+                @focusout="handleMatchRateFocusOut"
+              >
+                <input
+                  data-testid="recommend-match-rate-slider"
+                  type="range"
+                  :min="MATCH_RATE_MIN"
+                  :max="MATCH_RATE_MAX"
+                  step="1"
+                  class="match-rate-slider"
+                  :value="matchRateSliderValue"
+                  :aria-valuenow="matchRateSliderValue"
+                  @input="handleMatchRateSlider"
+                />
+                <input
+                  data-testid="recommend-match-rate"
+                  type="number"
+                  :min="MATCH_RATE_MIN"
+                  :max="MATCH_RATE_MAX"
+                  step="1"
+                  class="param-input"
+                  :placeholder="String(MATCH_RATE_DEFAULT)"
+                  :value="matchRateInput"
+                  @input="handleMatchRateInput"
+                />
+              </span>
+            </div>
+
+            <!--
+              Shown while either control has focus, whatever the field holds — the explanation is
+              needed *before* touching the field, not after changing it.
+
+              The element is always in the layout and only its visibility flips, so the results
+              table below does not jump up and down as focus comes and goes.
+            -->
+            <p
+              class="match-rate-hint"
+              :class="{ 'match-rate-hint--hidden': !matchRateFocused }"
+              data-testid="recommend-match-rate-hint"
+            >
+              <template v-if="matchRate === null">
+                Not set — the server default ({{ MATCH_RATE_DEFAULT }}%)
+                applies.
+              </template>
+              <template v-else>
+                Candidates at {{ matchRate }}% or above are shown as
+                highly-matched.
+              </template>
+              This only classifies the results; nothing is filtered out — use
+              Candidate Limit to change how many candidates come back.
+            </p>
           </section>
           <p-toolbox-table
             ref="toolboxTable"
@@ -494,9 +714,7 @@ function handleSave(e: { name: string; description: string }) {
             :style="{ height: '500px' }"
             :sortable="recommendInfraModel.tableModel.tableOptions.sortable"
             :sort-by="recommendInfraModel.tableModel.tableOptions.sortBy"
-            :selectable="
-              recommendInfraModel.tableModel.tableOptions.selectable
-            "
+            :selectable="recommendInfraModel.tableModel.tableOptions.selectable"
             :loading="resGetRecommendCost.isLoading.value"
             :select-index.sync="
               recommendInfraModel.tableModel.tableState.selectIndex
@@ -538,10 +756,10 @@ function handleSave(e: { name: string; description: string }) {
               </span>
             </template>
             <template #col-spec-format="{ item }">
-              <span v-html="formatEmptyValue(item.spec)"></span>
+              <span v-html="formatEmptyValue(item.spec)" />
             </template>
             <template #col-image-format="{ item }">
-              <span v-html="formatEmptyValue(item.image)"></span>
+              <span v-html="formatEmptyValue(item.image)" />
             </template>
           </p-toolbox-table>
         </div>
@@ -575,6 +793,24 @@ function handleSave(e: { name: string; description: string }) {
     >
       <template #body>
         <target-model-name-save :model-name="modelName" />
+      </template>
+      <!--
+        Override mirinae's built-in confirm button only to attach an e2e testid
+        (model-save-confirm). mirinae renders that button from the `button-text` prop, so a
+        data-testid cannot reach it otherwise. The replacement mirrors the default exactly —
+        same style-type (tertiary), same label, and the `margin-top` the default carries via
+        PIconModal's scoped `.button` rule (which does not reach parent-provided slot content)
+        is restored inline so the render is unchanged. (BAR-1595 / CLAUDE.md §12)
+      -->
+      <template #custom-button>
+        <p-button
+          style-type="tertiary"
+          data-testid="model-save-confirm"
+          style="margin-top: 1.5rem"
+          @click="handleConfirm"
+        >
+          Confirm
+        </p-button>
       </template>
     </p-icon-modal>
   </div>
@@ -621,5 +857,121 @@ function handleSave(e: { name: string; description: string }) {
 
 .recommend-candidate__flag {
   margin-right: 2px;
+}
+
+/* Query parameters — one row, hint on its own full-width line below. */
+.params-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+}
+
+.params-section__row {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 0.5rem;
+}
+
+.params-section__row > p {
+  white-space: nowrap;
+}
+
+/* Compact number fields. The spinner arrows force a taller box than the row needs, and the
+   slider already covers stepping through values, so they are dropped. */
+.param-input {
+  width: 60px;
+  height: 28px;
+  padding: 0 0.375rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  line-height: 1.2;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.param-input::-webkit-outer-spin-button,
+.param-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Fixed-width first cell, shared by both condition rows (Provider / Candidate Limit). Because
+   both rows use it, their second label starts at the same x whatever the dropdown contains. */
+.param-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 198px;
+  flex: none;
+}
+
+/* The '?' sits at the bottom-right of the label, like a footnote marker. */
+.match-rate-label {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 0.25rem;
+  white-space: nowrap;
+}
+
+.match-rate-label__help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  border: 1px solid #6b7280;
+  border-radius: 50%;
+  color: #6b7280;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  user-select: none;
+}
+
+.match-rate-label__help:hover,
+.match-rate-label__help:focus {
+  border-color: #1971c2;
+  color: #1971c2;
+  outline: none;
+}
+
+.match-rate-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.match-rate-slider {
+  width: 110px;
+  height: 28px;
+  cursor: pointer;
+}
+
+/* Its own line, so it gets the full width and does not wrap early. */
+.match-rate-hint {
+  color: #1971c2;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* Hidden but still occupying its line — flipping display here would shift the results table
+   every time focus enters or leaves the field. */
+.match-rate-hint--hidden {
+  visibility: hidden;
+}
+</style>
+
+<!-- global: the tooltip renders outside this component's DOM, so a scoped rule cannot reach it.
+     .tooltip-inner defaults to white-space:pre and a narrow box, which clips the explanation. -->
+<style lang="postcss">
+.p-tooltip.match-rate-tooltip .tooltip-inner {
+  max-width: 460px;
+  white-space: normal;
+  word-break: break-word;
+  text-align: left;
+  line-height: 1.45;
 }
 </style>


### PR DESCRIPTION
The recommendation screen offered a Min/Max pair for Minimum Match Rate and combined them into a range string such as `"90-100"`. The API takes one number (`minMatchRate`, 0-100, default 90); it cannot parse a range, so it logs a warning and quietly falls back to its default, and nothing the user typed ever took effect. With Min left empty the screen sent the Max value (100) instead, which the user never chose.

## What changed

- A single field: a 0-100 slider bound both ways to a number input, clamped as it is typed.
- The parameter is left out of the request entirely when the field is empty, so the server default applies.
- Spinner arrows dropped (the slider already steps through values); fields sized to keep the parameter row on one line.
- A `?` badge on the label opens the full explanation on hover. A line under the row appears while either control has focus: the rate classifies candidates as highly-matched or partially-matched and filters nothing out. That line keeps its place in the layout while hidden, so the results table does not shift as focus comes and goes.

## Verified

Verified against a running lineup: the value entered is what reaches the server, an empty field sends no parameter at all, and the parse-failure warning is gone from the server log.