### PR TITLE
Row editing in the JSON editor table view, and delivering its edits to the screens

### DIFF
--- a/docs/guide/quick-start-migration.md
+++ b/docs/guide/quick-start-migration.md
@@ -10,11 +10,11 @@ A migration runs through five steps, in order. Each one is a screen in the conso
 
 ```mermaid
 flowchart TD
-    A["<b>1 · Register Source Service</b><br/><small>connect to your source servers</small>"]
-    B["<b>2 · Create Source Model</b><br/><small>collect what is running there</small>"]
-    C["<b>3 · Create Target Model</b><br/><small>get a cloud spec recommendation, with cost</small>"]
-    D["<b>4 · Create Workflow</b><br/><small>generated from the target model</small>"]
-    E["<b>5 · Edit and Run Workflow</b><br/><small>the migration actually happens here</small>"]
+    A["1 · Register Source Service"]
+    B["2 · Create Source Model"]
+    C["3 · Create Target Model"]
+    D["4 · Create Workflow"]
+    E["5 · Edit and Run Workflow"]
 
     A --> B --> C --> D --> E
 

--- a/front/src/features/sourceServices/jsonViewer/ui/collectJsonEditor.vue
+++ b/front/src/features/sourceServices/jsonViewer/ui/collectJsonEditor.vue
@@ -51,7 +51,7 @@ function handleUpdate(value: string) {
         :status-bar="false"
         height="100%"
         file-name="collected-source"
-        @update:model-value="handleUpdate"
+        @update:modelValue="handleUpdate"
       />
     </div>
   </p-pane-layout>

--- a/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/EnhancedJsonEditor.vue
@@ -50,6 +50,14 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void;
+  /*
+    Vue 2 matches event names literally, so a parent listening on the hyphenated
+    "@update:model-value" never hears "update:modelValue". Three screens were
+    written that way and silently dropped every edit made in this editor. They
+    are fixed, and this alias is emitted alongside so the next one cannot break
+    the same way without anyone noticing.
+  */
+  (e: 'update:model-value', value: string): void;
   (e: 'update:mode', value: string): void;
   (e: 'change', value: { content: Content; previousContent: Content; changeStatus: OnChangeStatus }): void;
   (e: 'error', value: Error): void;
@@ -61,6 +69,13 @@ const editorRef = ref<HTMLElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 let editorInstance: JSONEditor | null = null;
 const currentMode = ref<Mode>(props.mode as Mode);
+/*
+  The menu's "table" button opens the Property Grid, not the library table mode.
+  The library lays out one row per array entry and refuses anything else, while
+  every document these editors handle - infra model, software model, workflow
+  definition - is an object at the root. So table mode has no table to draw here,
+  and the grid, which flattens any document to key/value rows, takes its place.
+*/
 const showPropertyGrid = ref(props.mode === 'table');
 const hasError = ref(false);
 const errorMessage = ref('');
@@ -107,6 +122,12 @@ function contentToString(content: Content): string {
 const showImport = computed(() => props.allowImport && !props.readOnly);
 const showExport = computed(() => props.allowExport);
 const showToolbar = computed(() => showImport.value || showExport.value);
+
+// Emit both spellings - see the note on the alias in defineEmits.
+function emitModelValue(value: string) {
+  emit('update:modelValue', value);
+  emit('update:model-value', value);
+}
 
 function setError(message: string) {
   hasError.value = true;
@@ -190,7 +211,7 @@ function applyImportedText(text: string, sourceName: string) {
   if (editorInstance) {
     editorInstance.update({ json } as Content);
   }
-  emit('update:modelValue', JSON.stringify(json, null, 2));
+  emitModelValue(JSON.stringify(json, null, 2));
   emit('import', { fileName: sourceName, json });
 }
 
@@ -223,7 +244,7 @@ function initEditor() {
 
   const editorProps: JSONEditorPropsOptional = {
     content: toContent(props.modelValue),
-    mode: currentMode.value === Mode.table ? Mode.tree : currentMode.value,
+    mode: currentMode.value,
     readOnly: props.readOnly,
     // Force mainMenuBar to show even when readOnly is true
     mainMenuBar: props.mainMenuBar,
@@ -239,23 +260,13 @@ function initEditor() {
       errorMessage.value = '';
       const strValue = contentToString(content);
       console.log('[EnhancedJsonEditor] Emitting update:modelValue:', JSON.stringify(strValue).substring(0, 100), 'type:', typeof strValue);
-      emit('update:modelValue', strValue);
+      emitModelValue(strValue);
       emit('change', { content, previousContent, changeStatus });
     },
     onChangeMode: (mode: Mode) => {
       currentMode.value = mode;
-      // When user clicks "table" in vanilla-jsoneditor menu, show Property Grid instead
-      if (mode === Mode.table) {
-        showPropertyGrid.value = true;
-        // Switch vanilla-jsoneditor back to tree (so it's ready when user switches back)
-        nextTick(() => {
-          if (editorInstance) {
-            editorInstance.updateProps({ mode: Mode.tree });
-          }
-        });
-      } else {
-        showPropertyGrid.value = false;
-      }
+      // The grid stands in for table mode - see the note by showPropertyGrid.
+      showPropertyGrid.value = mode === Mode.table;
       emit('update:mode', mode);
     },
     onError: (err: Error) => {
@@ -334,7 +345,7 @@ watch(
 );
 
 function handlePropertyGridUpdate(value: string) {
-  emit('update:modelValue', value);
+  emitModelValue(value);
   // Also sync to vanilla-jsoneditor
   if (editorInstance) {
     try {
@@ -343,18 +354,6 @@ function handlePropertyGridUpdate(value: string) {
       // ignore
     }
   }
-}
-
-function switchToEditor() {
-  showPropertyGrid.value = false;
-  currentMode.value = Mode.tree;
-
-  // Expand all when switching back to Tree mode
-  nextTick(() => {
-    if (editorInstance) {
-      editorInstance.expand(() => true);
-    }
-  });
 }
 
 // Expose methods for parent component
@@ -369,10 +368,10 @@ defineExpose({
   setMode: (mode: 'tree' | 'text' | 'table') => {
     if (!editorInstance) return;
     try {
-      // Property Grid is our custom mode
       if (mode === 'table' || mode === Mode.table) {
         showPropertyGrid.value = true;
-        editorInstance.updateProps({ mode: Mode.tree });
+        editorInstance.updateProps({ mode: Mode.table });
+        currentMode.value = Mode.table;
       } else {
         showPropertyGrid.value = false;
         const editorMode = mode === 'tree' ? Mode.tree : Mode.text;
@@ -458,23 +457,27 @@ defineExpose({
       />
     </div>
 
+    <!-- vanilla-jsoneditor - keeps the menu bar visible in every mode -->
+    <div
+      ref="editorRef"
+      class="editor-container"
+      :class="{ 'menu-only': showPropertyGrid }"
+    />
+
     <!-- Property Grid view (replaces vanilla-jsoneditor table mode) -->
-    <div v-if="showPropertyGrid" class="property-grid-wrapper">
-      <div class="pg-header">
-        <span class="pg-header-title">Property Grid</span>
-        <button class="pg-back-btn" @click="switchToEditor">
-          ← Back to Tree / Code
-        </button>
-      </div>
+    <!--
+      Kept mounted and merely hidden. Tearing it down on every mode change threw
+      inside Vue's own teardown and left the editor unable to open the grid again;
+      keeping it also preserves what the user had expanded and their undo history.
+    -->
+    <div v-show="showPropertyGrid" class="property-grid-wrapper">
       <JsonPropertyGrid
         :data="modelValue"
         :read-only="readOnly"
+        :active="showPropertyGrid"
         @update:data="handlePropertyGridUpdate"
       />
     </div>
-
-    <!-- vanilla-jsoneditor (tree / text modes) -->
-    <div v-show="!showPropertyGrid" ref="editorRef" class="editor-container" />
 
     <!-- Error indicator - also carries Import/Export failures, so it must show in Property Grid mode as well -->
     <div v-if="hasError" class="error-bar">
@@ -573,33 +576,27 @@ defineExpose({
   overflow: hidden;
 }
 
-.pg-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 12px;
-  background: #f3f4f6;
-  border-bottom: 1px solid #e5e7eb;
-  flex-shrink: 0;
-}
+/*
+  While the grid is showing, the library keeps its menu bar - that bar is how the
+  user moves between text, tree and table, and it marks which one they are on. Only
+  the editor's own content is hidden, and the grid takes that space.
+*/
+.editor-container.menu-only {
+  flex: 0 0 auto;
+  min-height: 0;
+  overflow: visible;
 
-.pg-header-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: #4b5563;
-}
+  :deep(.jse-main) {
+    min-height: 0 !important;
+  }
 
-.pg-back-btn {
-  padding: 3px 10px;
-  font-size: 11px;
-  color: #6366f1;
-  background: #ffffff;
-  border: 1px solid #c7d2fe;
-  border-radius: 3px;
-  cursor: pointer;
-
-  &:hover {
-    background: #eef2ff;
+  /*
+    The menu bar is not a direct child of .jse-main - it sits inside the wrapper
+    for the current mode (.jse-table-mode and friends). Hiding that wrapper takes
+    the menu with it, so hide what is beside the menu instead.
+  */
+  :deep(.jse-main > * > *:not(.jse-menu)) {
+    display: none !important;
   }
 }
 

--- a/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
+++ b/front/src/shared/ui/EnhancedJsonEditor/JsonPropertyGrid.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 
 interface Props {
   data: any;
   readOnly?: boolean;
+  /** False while another view is on screen - keyboard shortcuts stay out of the way. */
+  active?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   readOnly: false,
+  active: true,
 });
 
 const emit = defineEmits<{
@@ -20,12 +23,26 @@ const expandedPaths = ref<Set<string>>(new Set());
 // Search
 const searchQuery = ref('');
 
+/*
+  Undo / redo state, and the flag that marks a change as our own.
+  Declared here because the watcher below runs immediately during setup and reads
+  them - declaring them further down left that first run reaching for bindings
+  that did not exist yet, which took the whole grid down on its second open.
+*/
+const selfEdit = ref(false);
+const undoStack = ref<string[]>([]);
+const redoStack = ref<string[]>([]);
+const canUndo = computed(() => undoStack.value.length > 0);
+const canRedo = computed(() => redoStack.value.length > 0);
+
 interface FlatRow {
   key: string;
   displayKey: string;
   value: any;
   depth: number;
   path: string;
+  /** Path as segments. Used for every write - a key containing "." breaks a string path. */
+  keys: string[];
   isExpandable: boolean;
   isExpanded: boolean;
   valueType: string;
@@ -49,7 +66,13 @@ function getValueDisplay(row: FlatRow): string {
   return String(v);
 }
 
-function flattenJson(data: any, parentPath: string, depth: number, isArrayParent: boolean): FlatRow[] {
+function flattenJson(
+  data: any,
+  parentPath: string,
+  depth: number,
+  isArrayParent: boolean,
+  parentKeys: string[] = [],
+): FlatRow[] {
   const rows: FlatRow[] = [];
   if (data === null || data === undefined || typeof data !== 'object') return rows;
 
@@ -59,6 +82,7 @@ function flattenJson(data: any, parentPath: string, depth: number, isArrayParent
 
   for (const [key, value] of entries) {
     const path = `${parentPath}.${key}`;
+    const keys = [...parentKeys, key];
     const isExpandable = value !== null && typeof value === 'object';
     const isExpanded = expandedPaths.value.has(path);
 
@@ -68,6 +92,7 @@ function flattenJson(data: any, parentPath: string, depth: number, isArrayParent
       value,
       depth,
       path,
+      keys,
       isExpandable,
       isExpanded,
       valueType: getValueType(value),
@@ -78,7 +103,9 @@ function flattenJson(data: any, parentPath: string, depth: number, isArrayParent
     });
 
     if (isExpandable && isExpanded) {
-      rows.push(...flattenJson(value, path, depth + 1, Array.isArray(value)));
+      rows.push(
+        ...flattenJson(value, path, depth + 1, Array.isArray(value), keys),
+      );
     }
   }
 
@@ -163,10 +190,24 @@ function expandToDepth(maxDepth: number) {
   expandedPaths.value = paths;
 }
 
-// Default: expand first 2 levels
-watch(parsedData, () => {
-  expandToDepth(2);
-}, { immediate: true });
+/*
+  Default: expand first 2 levels.
+  Our own edits come back through props, and collapsing the tree back to depth 2
+  on every one of them would hide the entry the user just added.
+*/
+watch(
+  parsedData,
+  () => {
+    if (selfEdit.value) {
+      selfEdit.value = false;
+      return;
+    }
+    undoStack.value = [];
+    redoStack.value = [];
+    expandToDepth(2);
+  },
+  { immediate: true },
+);
 
 function getTypeClass(type: string): string {
   const map: Record<string, string> = {
@@ -190,6 +231,184 @@ function startEdit(row: FlatRow) {
   editValue.value = row.valueType === 'string' ? row.value : String(row.value);
 }
 
+/* Row operations
+   ------------------------------------------------------------------
+   The grid is the view people actually use on these documents, because the
+   library table mode only opens arrays and our models are objects at the root.
+   So adding a row has to work here: keep the keys of the row we copy from, and
+   the new entry arrives with every column already in place. */
+
+function cloneData(): any {
+  return JSON.parse(JSON.stringify(parsedData.value));
+}
+
+// Walk to the container that holds the row, so the last key can be written.
+function containerOf(data: any, keys: string[]): any {
+  let current = data;
+  for (const key of keys.slice(0, -1)) current = current[key];
+  return current;
+}
+
+/*
+  Undo / redo.
+  The tree and text views have it, and this is the third view of the same document
+  - having it only there makes the table feel like someone else's screen. The stack
+  holds whole documents, which is cheap enough here and cannot drift out of step
+  with the parent. An edit arriving from anywhere else clears it, since the history
+  belongs to the document we were handed.
+*/
+function currentText(): string {
+  return JSON.stringify(parsedData.value, null, 2);
+}
+
+function apply(text: string) {
+  selfEdit.value = true;
+  emit('update:data', text);
+}
+
+function commit(data: any) {
+  undoStack.value.push(currentText());
+  redoStack.value = [];
+  apply(JSON.stringify(data, null, 2));
+}
+
+function undo() {
+  const previous = undoStack.value.pop();
+  if (previous === undefined) return;
+  redoStack.value.push(currentText());
+  apply(previous);
+}
+
+function redo() {
+  const next = redoStack.value.pop();
+  if (next === undefined) return;
+  undoStack.value.push(currentText());
+  apply(next);
+}
+
+const canEdit = computed(() => !props.readOnly);
+
+function copyOf(value: any): any {
+  return JSON.parse(JSON.stringify(value ?? null));
+}
+
+/*
+  Duplicate means one thing everywhere: copy this row, put the copy right below it.
+
+  It used to also sit on the list row itself, where clicking it appended a child
+  instead of copying the row - the same icon meaning two different things depending
+  on where it sat. On a list row people reasonably expect the list to be copied, so
+  the button is simply not offered there. A list is filled by duplicating one of its
+  entries, which is the case that matters.
+*/
+function canDuplicate(row: FlatRow): boolean {
+  return canEdit.value && row.isArrayItem;
+}
+
+function canRemove(row: FlatRow): boolean {
+  return canEdit.value && row.keys.length > 0;
+}
+
+/*
+  The copy carries the same keys as the entry it came from, so a new firewall rule
+  arrives with every column in place and only the values to change.
+*/
+function duplicateRow(row: FlatRow) {
+  if (!canDuplicate(row)) return;
+  const data = cloneData();
+  const container = containerOf(data, row.keys);
+  if (!Array.isArray(container)) return;
+
+  const index = Number(row.keys[row.keys.length - 1]);
+  container.splice(index + 1, 0, copyOf(container[index]));
+  commit(data);
+}
+
+function removeRow(row: FlatRow) {
+  if (!canRemove(row)) return;
+  const data = cloneData();
+  const container = containerOf(data, row.keys);
+  const key = row.keys[row.keys.length - 1];
+
+  if (Array.isArray(container)) container.splice(Number(key), 1);
+  else delete container[key];
+  commit(data);
+}
+
+/*
+  Hover hint - a real layer rather than the browser's tooltip, so the wording can
+  say what the duplicate button does: it copies the entry it sits on rather than
+  adding an empty one, and the copy lands right below.
+*/
+const hint = ref<{ x: number; y: number; text: string } | null>(null);
+const duplicateHint =
+  'Duplicate this entry. The copy lands just below it with every field already in place - only the values need changing.';
+const removeHint =
+  'Remove this entry from the document. Nothing else is touched.';
+
+function showHint(event: MouseEvent | FocusEvent, text: string) {
+  const box = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  hint.value = { x: box.left + box.width / 2, y: box.top, text };
+}
+
+function hideHint() {
+  hint.value = null;
+}
+
+/* Right-click menu - the row buttons sit at the far right of a wide table, which
+   is a long way to travel when the row you want is on the left. */
+const rowMenu = ref<{ x: number; y: number; row: FlatRow } | null>(null);
+
+function openRowMenu(event: MouseEvent, row: FlatRow) {
+  if (!canEdit.value || !props.active) return;
+  if (!canDuplicate(row) && !canRemove(row)) return;
+  event.preventDefault();
+  rowMenu.value = { x: event.clientX, y: event.clientY, row };
+}
+
+/*
+  A click inside the menu must not reach the document listener that closes it.
+  The modifier alone would do, but Vue 2 then registers a listener with no
+  handler and throws while removing it - which corrupts the patch and, among
+  other things, stops cell edits from being applied.
+*/
+function keepMenuOpen() {}
+
+function closeRowMenu() {
+  rowMenu.value = null;
+}
+
+function runFromMenu(action: 'duplicate' | 'remove') {
+  const row = rowMenu.value?.row;
+  closeRowMenu();
+  if (!row) return;
+  if (action === 'duplicate') duplicateRow(row);
+  else removeRow(row);
+}
+
+onMounted(() => {
+  document.addEventListener('click', closeRowMenu);
+  document.addEventListener('keydown', onKeydown);
+});
+onBeforeUnmount(() => {
+  document.removeEventListener('click', closeRowMenu);
+  document.removeEventListener('keydown', onKeydown);
+});
+function onKeydown(e: KeyboardEvent) {
+  if (!props.active) return;
+  if (e.key === 'Escape') {
+    closeRowMenu();
+    return;
+  }
+  // While a cell is open for editing, the input owns undo.
+  if (editingPath.value !== null || props.readOnly) return;
+  const key = e.key.toLowerCase();
+  if (!(e.ctrlKey || e.metaKey) || key !== 'z') return;
+  e.preventDefault();
+  if (e.shiftKey) redo();
+  else undo();
+}
+
 function confirmEdit(row: FlatRow) {
   if (!editingPath.value) return;
 
@@ -205,15 +424,10 @@ function confirmEdit(row: FlatRow) {
   }
 
   // Apply change to data
-  const pathParts = row.path.replace('$.', '').split('.');
-  const newData = JSON.parse(JSON.stringify(parsedData.value));
-  let current: any = newData;
-  for (let i = 0; i < pathParts.length - 1; i++) {
-    current = current[pathParts[i]];
-  }
-  current[pathParts[pathParts.length - 1]] = newValue;
+  const newData = cloneData();
+  containerOf(newData, row.keys)[row.keys[row.keys.length - 1]] = newValue;
 
-  emit('update:data', JSON.stringify(newData, null, 2));
+  commit(newData);
   editingPath.value = null;
 }
 
@@ -227,22 +441,58 @@ function cancelEdit() {
     <!-- Toolbar -->
     <div class="pg-toolbar">
       <div class="pg-toolbar-left">
-        <button class="pg-btn" @click="expandAll" title="Expand All">
-          <span class="pg-icon">&#9660;</span> Expand All
+        <button
+          class="pg-btn pg-btn-icon"
+          data-testid="json-grid-undo"
+          title="Undo (Ctrl+Z)"
+          :disabled="!canUndo"
+          @click="undo"
+        >
+          &#8630;
         </button>
-        <button class="pg-btn" @click="collapseAll" title="Collapse All">
-          <span class="pg-icon">&#9654;</span> Collapse All
+        <button
+          class="pg-btn pg-btn-icon"
+          data-testid="json-grid-redo"
+          title="Redo (Ctrl+Shift+Z)"
+          :disabled="!canRedo"
+          @click="redo"
+        >
+          &#8631;
         </button>
-        <button class="pg-btn" @click="expandToDepth(2)" title="Depth 2">
+        <span class="pg-toolbar-sep" />
+        <button class="pg-btn" title="Expand all" @click="expandAll">
+          <span class="pg-icon">&#9660;</span> Expand all
+        </button>
+        <button class="pg-btn" title="Collapse all" @click="collapseAll">
+          <span class="pg-icon">&#9654;</span> Collapse all
+        </button>
+        <span class="pg-toolbar-sep" />
+        <button
+          class="pg-btn"
+          title="Expand 2 levels"
+          @click="expandToDepth(2)"
+        >
           D2
         </button>
-        <button class="pg-btn" @click="expandToDepth(3)" title="Depth 3">
+        <button
+          class="pg-btn"
+          title="Expand 3 levels"
+          @click="expandToDepth(3)"
+        >
           D3
         </button>
-        <button class="pg-btn" @click="expandToDepth(5)" title="Depth 5">
+        <button
+          class="pg-btn"
+          title="Expand 5 levels"
+          @click="expandToDepth(5)"
+        >
           D5
         </button>
-        <button class="pg-btn" @click="expandToDepth(7)" title="Depth 7">
+        <button
+          class="pg-btn"
+          title="Expand 7 levels"
+          @click="expandToDepth(7)"
+        >
           D7
         </button>
       </div>
@@ -263,6 +513,7 @@ function cancelEdit() {
           <tr>
             <th class="pg-th-key">Property</th>
             <th class="pg-th-value">Value</th>
+            <th v-if="canEdit" class="pg-th-actions">Row</th>
           </tr>
         </thead>
         <tbody>
@@ -270,6 +521,7 @@ function cancelEdit() {
             v-for="row in filteredRows"
             :key="row.path"
             :class="['pg-row', `depth-${Math.min(row.depth, 8)}`]"
+            @contextmenu="openRowMenu($event, row)"
           >
             <!-- Key column -->
             <td
@@ -321,14 +573,89 @@ function cancelEdit() {
                 </template>
               </template>
             </td>
+
+            <!-- Row actions -->
+            <td v-if="canEdit" class="pg-cell-actions">
+              <button
+                v-if="canDuplicate(row)"
+                class="pg-row-btn"
+                data-testid="json-grid-row-duplicate"
+                @click="duplicateRow(row)"
+                @mouseenter="showHint($event, duplicateHint)"
+                @mouseleave="hideHint"
+                @focus="showHint($event, duplicateHint)"
+                @blur="hideHint"
+              >
+                <svg class="pg-row-icon" viewBox="0 0 16 16" aria-hidden="true">
+                  <path
+                    d="M10.5 1.5h-6a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1Zm-6-1h6a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-6a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2Z"
+                  />
+                  <path
+                    d="M13.5 4.5a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-6a2 2 0 0 1-2-2v-.5h1v.5a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1H13v-1h.5Z"
+                  />
+                </svg>
+              </button>
+              <button
+                v-if="canRemove(row)"
+                class="pg-row-btn pg-row-btn-danger"
+                data-testid="json-grid-row-remove"
+                @click="removeRow(row)"
+                @mouseenter="showHint($event, removeHint)"
+                @mouseleave="hideHint"
+                @focus="showHint($event, removeHint)"
+                @blur="hideHint"
+              >
+                <svg class="pg-row-icon" viewBox="0 0 16 16" aria-hidden="true">
+                  <path
+                    d="M6.5 1.5h3a.5.5 0 0 1 .5.5v.5h3a.5.5 0 0 1 0 1h-.554l-.7 9.1a1.5 1.5 0 0 1-1.496 1.4H5.75a1.5 1.5 0 0 1-1.496-1.4l-.7-9.1H3a.5.5 0 0 1 0-1h3V2a.5.5 0 0 1 .5-.5Zm-1.94 2 .69 9.024a.5.5 0 0 0 .5.476h4.5a.5.5 0 0 0 .5-.476l.69-9.024H4.56ZM7 5.5a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2 0a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Z"
+                  />
+                </svg>
+              </button>
+            </td>
           </tr>
           <tr v-if="filteredRows.length === 0">
-            <td colspan="2" class="pg-empty">
+            <td :colspan="canEdit ? 3 : 2" class="pg-empty">
               {{ searchQuery ? 'No matching results' : 'Empty data' }}
             </td>
           </tr>
         </tbody>
       </table>
+    </div>
+
+    <!-- Hover hint -->
+    <div
+      v-if="hint"
+      class="pg-hint"
+      data-testid="json-grid-hint"
+      :style="{ left: hint.x + 'px', top: hint.y + 'px' }"
+    >
+      {{ hint.text }}
+    </div>
+
+    <!-- Right-click menu -->
+    <div
+      v-if="rowMenu"
+      class="pg-menu"
+      data-testid="json-grid-row-menu"
+      :style="{ left: rowMenu.x + 'px', top: rowMenu.y + 'px' }"
+      @click.stop="keepMenuOpen"
+    >
+      <button
+        v-if="canDuplicate(rowMenu.row)"
+        class="pg-menu-item"
+        data-testid="json-grid-menu-duplicate"
+        @click="runFromMenu('duplicate')"
+      >
+        Duplicate this entry
+      </button>
+      <button
+        v-if="canRemove(rowMenu.row)"
+        class="pg-menu-item pg-menu-item-danger"
+        data-testid="json-grid-menu-remove"
+        @click="runFromMenu('remove')"
+      >
+        Remove this entry
+      </button>
     </div>
   </div>
 </template>
@@ -343,15 +670,23 @@ function cancelEdit() {
 }
 
 /* Toolbar */
+/* Matches the library menu bar, so the three views read as one screen. */
 .pg-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 4px 8px;
-  background: #f8f9fa;
+  padding: 3px 6px;
+  background: #f9fafb;
   border-bottom: 1px solid #e5e7eb;
   flex-shrink: 0;
   gap: 8px;
+}
+
+.pg-toolbar-sep {
+  width: 1px;
+  height: 16px;
+  margin: 0 3px;
+  background: #e5e7eb;
 }
 
 .pg-toolbar-left {
@@ -360,19 +695,34 @@ function cancelEdit() {
 }
 
 .pg-btn {
-  padding: 3px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 24px;
+  padding: 0 8px;
   font-size: 11px;
-  color: #4b5563;
-  background: #ffffff;
-  border: 1px solid #d1d5db;
+  color: #374151;
+  background: transparent;
+  border: 0;
   border-radius: 3px;
   cursor: pointer;
   white-space: nowrap;
 
-  &:hover {
-    background: #f3f4f6;
-    color: #1f2937;
+  &:hover:not(:disabled) {
+    background: #e5e7eb;
   }
+
+  &:disabled {
+    color: #d1d5db;
+    cursor: default;
+  }
+}
+
+.pg-btn-icon {
+  justify-content: center;
+  width: 26px;
+  padding: 0;
+  font-size: 14px;
 }
 
 .pg-icon {
@@ -407,7 +757,8 @@ function cancelEdit() {
 }
 
 .pg-th-key,
-.pg-th-value {
+.pg-th-value,
+.pg-th-actions {
   position: sticky;
   top: 0;
   padding: 6px 8px;
@@ -428,6 +779,111 @@ function cancelEdit() {
 
 .pg-th-value {
   width: 55%;
+}
+
+.pg-th-actions {
+  width: 92px;
+  text-align: right;
+}
+
+.pg-cell-actions {
+  padding: 3px 6px;
+  text-align: right;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.pg-row-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 20px;
+  padding: 0;
+  margin-left: 2px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #4b5563;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  cursor: pointer;
+  opacity: 0;
+
+  &:hover {
+    background: #eef2ff;
+    border-color: #c7d2fe;
+    color: #4f46e5;
+  }
+}
+
+.pg-row-btn-danger:hover {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #dc2626;
+}
+
+/* Keep the row quiet until it is the one being worked on. */
+.pg-row:hover .pg-row-btn,
+.pg-row-btn:focus {
+  opacity: 1;
+}
+
+.pg-hint {
+  position: fixed;
+  z-index: 60;
+  max-width: 260px;
+  padding: 6px 9px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #f9fafb;
+  background: #111827;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 18%);
+  transform: translate(-50%, calc(-100% - 8px));
+  pointer-events: none;
+}
+
+/* Both row icons share one box so they line up on the same baseline. */
+.pg-row-icon {
+  display: block;
+  width: 13px;
+  height: 13px;
+  fill: currentcolor;
+}
+
+.pg-menu {
+  position: fixed;
+  z-index: 50;
+  min-width: 148px;
+  padding: 4px;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+}
+
+.pg-menu-item {
+  display: block;
+  width: 100%;
+  padding: 5px 10px;
+  font-size: 12px;
+  color: #374151;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 3px;
+  cursor: pointer;
+
+  &:hover {
+    background: #eef2ff;
+    color: #4f46e5;
+  }
+}
+
+.pg-menu-item-danger:hover {
+  background: #fef2f2;
+  color: #dc2626;
 }
 
 .pg-row {

--- a/front/src/widgets/models/sourceModels/customViewSourceModel/ui/CustomViewSourceModel.vue
+++ b/front/src/widgets/models/sourceModels/customViewSourceModel/ui/CustomViewSourceModel.vue
@@ -215,7 +215,7 @@ function handleCodeUpdate(value: string) {
             :status-bar="true"
             height="600px"
             file-name="source-model"
-            @update:model-value="handleCodeUpdate"
+            @update:modelValue="handleCodeUpdate"
           />
         </div>
       </template>

--- a/front/src/widgets/models/targetModels/customViewTargetModel/ui/CustomViewTargetModel.vue
+++ b/front/src/widgets/models/targetModels/customViewTargetModel/ui/CustomViewTargetModel.vue
@@ -209,7 +209,7 @@ function handleCodeUpdate(value: string) {
             :status-bar="true"
             height="600px"
             file-name="target-model"
-            @update:model-value="handleCodeUpdate"
+            @update:modelValue="handleCodeUpdate"
           />
         </div>
       </template>


### PR DESCRIPTION
Adding one more entry to a list in a model — a firewall rule, for example — meant picking through the tree or typing into the raw text. The table view could edit values but not change the shape of the document.

**Row editing.** An entry can now be duplicated, which copies it in full so the new one arrives with every field in place and only the values to change. An entry can also be removed. Both are available on the row and from a right-click, and hovering explains that duplicating copies rather than adding a blank entry. Undo and redo work here as they do in the other views.

**Edits now reach the screen that hosts the editor.** Three screens listened for the editor's change notification under a name it does not emit, so nothing done in the editor on those screens ever arrived — not a value edit, not an import. The library views keep their own state, which made edits look applied right up until save wrote the original document back. The three call sites are fixed, and the editor emits both spellings so a screen written the other way cannot fail silently.

**The library table mode is no longer used by these editors.** It lays out one row per array entry and refuses anything else, and every document these screens handle is an object at the root, so it never had a table to draw.

The overview diagram in the quick start guide is also kept to step names, since the renderer does not lay out the markup the subtitles needed.

Verified on a running console: values and duplicated entries survive save and reopen, an exported file matches the screen and can be edited, imported and saved, and the three views switch back and forth cleanly.