### PR TITLE
fix(menu): withhold Cloud Resources until credentials can be managed safely

### DIFF
--- a/api/conf/menu.yaml
+++ b/api/conf/menu.yaml
@@ -54,12 +54,23 @@ menus:
     isaction: "false"
     priority: 5
   
-  - id: cloudresources
-    parentid: migrations
-    displayname: Cloud Resources
-    restype: menu
-    isaction: "false"
-    priority: 6
+  # Cloud Resources is hidden until credential management can be offered safely.
+  #
+  # Registering a credential fans out into one connection config per region, and
+  # there is no way to remove it again - the upstream framework has no delete
+  # route - so a mistaken entry cannot be undone from the console, and those
+  # connections are what later provisioning and spec recommendation run on.
+  # Credentials are registered through the setup procedure in the meantime.
+  #
+  # The screens themselves are untouched; only the menu, the reachable list and
+  # the routes are disconnected. Restore all three together.
+  #
+  # - id: cloudresources
+  #   parentid: migrations
+  #   displayname: Cloud Resources
+  #   restype: menu
+  #   isaction: "false"
+  #   priority: 6
 
   ################## step3 : menu : migrations > sourcecomputing ################
   - id: sourceservices
@@ -122,19 +133,21 @@ menus:
     priority: 0
   
   ################## step3 : menu : migrations > workloadoperations ################
-  - id: cloudcredentials
-    parentid: cloudresources
-    displayname: Cloud Credentials
-    restype: menu
-    isaction: "true"
-    priority: 0
-
-  - id: apis
-    parentid: cloudresources
-    displayname: APIs
-    restype: menu
-    isaction: "true"
-    priority: 1
+  # Hidden along with their Cloud Resources parent - see the note there.
+  #
+  # - id: cloudcredentials
+  #   parentid: cloudresources
+  #   displayname: Cloud Credentials
+  #   restype: menu
+  #   isaction: "true"
+  #   priority: 0
+  #
+  # - id: apis
+  #   parentid: cloudresources
+  #   displayname: APIs
+  #   restype: menu
+  #   isaction: "true"
+  #   priority: 1
 
   ###################### step4 : submenu : migrations > workloadoperations > workloads ################
   - id: mciwls

--- a/front/src/app/providers/router/routes/cloudResources.ts
+++ b/front/src/app/providers/router/routes/cloudResources.ts
@@ -1,32 +1,43 @@
 import { RouteConfig } from 'vue-router';
-import { CLOUD_RESOURCES_ROUTE } from '@/app/providers/router/routes/constants';
-import { cloudCredentialsPage, apisPage } from '@/pages/cloudResources';
+// import { CLOUD_RESOURCES_ROUTE } from '@/app/providers/router/routes/constants';
+// import { cloudCredentialsPage, apisPage } from '@/pages/cloudResources';
 
+/*
+  Cloud Resources is withheld until credential management can be offered safely.
+  The reasoning is in api/conf/menu.yaml, which drops the same entries from the
+  menu tree the server hands out.
 
+  The routes go too, not just the menu. Hiding a menu still leaves the address
+  reachable by typing it, and these screens can write state that cannot be
+  undone from the console.
+
+  The pages and widgets are left in place - only the wiring is cut. Restoring
+  means putting back this file, the menu tree and the reachable list together.
+*/
 export const cloudResourcesRoutes: RouteConfig[] = [
-  {
-    path: 'cloud-resources',
-    name: CLOUD_RESOURCES_ROUTE._NAME,
-    component: { template: '<router-view/>' },
-    children: [
-      {
-        path: 'cloud-credentials',
-        name: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
-        component: cloudCredentialsPage,
-        meta: {
-          menuId: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
-          category: CLOUD_RESOURCES_ROUTE._NAME,
-        },
-      },
-      {
-        path: 'apis',
-        name: CLOUD_RESOURCES_ROUTE.APIS._NAME,
-        component: apisPage,
-        meta: {
-          menuId: CLOUD_RESOURCES_ROUTE.APIS._NAME,
-          category: CLOUD_RESOURCES_ROUTE._NAME,
-        },
-      },
-    ],
-  },
+  // {
+  //   path: 'cloud-resources',
+  //   name: CLOUD_RESOURCES_ROUTE._NAME,
+  //   component: { template: '<router-view/>' },
+  //   children: [
+  //     {
+  //       path: 'cloud-credentials',
+  //       name: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
+  //       component: cloudCredentialsPage,
+  //       meta: {
+  //         menuId: CLOUD_RESOURCES_ROUTE.CLOUD_CREDENTIALS._NAME,
+  //         category: CLOUD_RESOURCES_ROUTE._NAME,
+  //       },
+  //     },
+  //     {
+  //       path: 'apis',
+  //       name: CLOUD_RESOURCES_ROUTE.APIS._NAME,
+  //       component: apisPage,
+  //       meta: {
+  //         menuId: CLOUD_RESOURCES_ROUTE.APIS._NAME,
+  //         category: CLOUD_RESOURCES_ROUTE._NAME,
+  //       },
+  //     },
+  //   ],
+  // },
 ];

--- a/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
+++ b/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
@@ -28,8 +28,12 @@ const REACHABLE_MENU_IDS: string[] = [
   MENU_ID.WORKFLOW_TEMPLATES,
   MENU_ID.TASK_COMPONENTS,
   MENU_ID.WORKLOADS,
-  MENU_ID.CLOUD_CREDENTIALS,
-  'apis',
+  // Cloud Credentials and APIs are withheld until credential management can be
+  // offered safely - the reasoning is in api/conf/menu.yaml, where the menu tree
+  // itself drops them. Kept here, commented, so restoring means putting back the
+  // same three places rather than rediscovering them.
+  // MENU_ID.CLOUD_CREDENTIALS,
+  // 'apis',
 ];
 
 function isReachable(menuId: string): boolean {


### PR DESCRIPTION
## What

Cloud Resources and its two entries, Cloud Credentials and APIs, are removed from the console - from the menu tree the server hands out, from the reachable menu list, and from the routes.

## Why

The screens are reachable today but cannot be used safely.

Registering a credential fans out into one connection config per region, and there is no delete route for credentials, so a mistaken entry cannot be undone from the console. Those connection configs are what later provisioning and spec recommendation run on, which makes a wrong entry more than a cosmetic problem.

Credential ownership also reaches past this screen. Picking an owner only takes effect if the matching header rides along on every later call, and the console does not send it, so the screen would disagree with what actually happens - without any error to show for it.

Loading common assets takes longer than the front proxy will hold a connection open, and there is no endpoint to poll for progress, so the request is cut off while the work continues on the server.

Credentials can still be registered through the initialization procedure.

## Notes

The routes are withheld as well, not just the menu - hiding a menu still leaves the address reachable by typing it, and these screens can write state that cannot be undone.

The pages and widgets are left in place. Only the wiring is cut, so bringing them back means restoring the same three places.

## Verified

On a test deployment of this branch, compared against an unchanged one: the three entries are absent from the menu tree and the sidebar, and both addresses land on the 404 page. The same checks give the opposite result on the unchanged deployment, so they can fail as well as pass.