### PR TITLE
feat(workload): add lifecycle control (suspend/resume/reboot/terminate)

### DIFF
--- a/front/src/entities/mci/api/index.ts
+++ b/front/src/entities/mci/api/index.ts
@@ -17,6 +17,72 @@ export interface IDeleteMciParams {
   option?: string;
 }
 
+/**
+ * The lifecycle actions this console offers.
+ *
+ * cb-tumblebug accepts more (`refine`, `reconcile`, `abort`, `continue`, `withdraw`), but those are
+ * crash recovery and hold-mode gates — an operator picks them knowing the exact state the infra is
+ * stuck in. Listing them beside Suspend and Reboot invites the wrong click, so they stay out.
+ */
+export type LifecycleAction = 'suspend' | 'resume' | 'reboot' | 'terminate';
+
+export interface IControlMciParams {
+  nsId: string;
+  infraId: string;
+  action: LifecycleAction;
+  /**
+   * Skips cb-tumblebug's two state checks: "another action is already running" and "this transition
+   * is not allowed from the current status".
+   *
+   * ★ Not the same `force` as deletion. Deleting with force drops the CB-TB records and leaves the
+   *   CSP resources running; this one touches no records and leaves nothing behind. Reusing the
+   *   delete wording here would tell the user something untrue.
+   */
+  force?: boolean;
+}
+
+export interface IControlMciNodeParams extends IControlMciParams {
+  nodeId: string;
+}
+
+/** cb-tumblebug answers control calls with a single message line (model.SimpleMsg). */
+export interface IControlResult {
+  message?: string;
+}
+
+function controlQueryParams(action: LifecycleAction, force?: boolean) {
+  const queryParams: Record<string, string> = { action };
+  // Sent only when asked for. cb-tumblebug reads it as `force == "true"`, so an absent key and
+  // "false" mean the same thing, and leaving it out keeps the call as narrow as what was requested.
+  if (force) queryParams.force = 'true';
+  return queryParams;
+}
+
+/**
+ * Control the whole infra — every node moves together.
+ *
+ * The response is an acknowledgement, not a completion: it comes back as "Suspending the Infra"
+ * while the CSP is still working. The list Status column is what shows the transition finishing.
+ */
+export function useControlMci(params: IControlMciParams) {
+  return useAxiosPost<IAxiosResponse<IControlResult>, any>(CONTROL_INFRA, {
+    pathParams: { nsId: params.nsId, infraId: params.infraId },
+    queryParams: controlQueryParams(params.action, params.force),
+  });
+}
+
+/** Control a single node. Same four actions; the infra's other nodes are left alone. */
+export function useControlMciNode(params: IControlMciNodeParams) {
+  return useAxiosPost<IAxiosResponse<IControlResult>, any>(CONTROL_INFRA_NODE, {
+    pathParams: {
+      nsId: params.nsId,
+      infraId: params.infraId,
+      nodeId: params.nodeId,
+    },
+    queryParams: controlQueryParams(params.action, params.force),
+  });
+}
+
 // The migration console queries infrastructure through cm-beetle rather than calling cb-tumblebug directly.
 // (beetle internally calls tumblebug ReadAllInfra/ReadInfra and the response models are identical.)
 // GetInfra exists on both cb-tumblebug and cm-beetle, so operationId alone collides — we use explicit subsystem routing.
@@ -27,6 +93,18 @@ const DELETE_INFRA = 'cm-beetle/DeleteInfra';
 // To handle long-running requests such as infra deletion asynchronously, we send reqId as a header on delete
 // and poll progress with this operationId. tumblebug also has GetRequest, so the prefix is required.
 const GET_BEETLE_REQUEST = 'cm-beetle/GetRequest';
+
+// Lifecycle control belongs to cb-tumblebug, not cm-beetle.
+//
+// Everything else on this screen goes through cm-beetle, so control would naturally go there too —
+// but cm-beetle has no such endpoint. Its infra surface is migrate / get / list / delete and nothing
+// more (checked against v0.5.6 and against every cm-beetle operationId in api.yaml). cm-beetle owns
+// the *migration*; running what the migration produced stayed with cb-tumblebug.
+//
+// Both operationIds are already registered in api.yaml, so no backend change is needed. If cm-beetle
+// ever grows a control API, these two constants are the only thing that has to move.
+const CONTROL_INFRA = 'cb-tumblebug/GetControlInfra';
+const CONTROL_INFRA_NODE = 'cb-tumblebug/GetControlInfraNode';
 
 export function useGetMciList(projectId: string | null, option: string | null) {
   const requestBodyWrapper: Required<

--- a/front/src/features/workload/lifecycleControl/model/index.ts
+++ b/front/src/features/workload/lifecycleControl/model/index.ts
@@ -1,0 +1,240 @@
+import { reactive } from 'vue';
+import {
+  useControlMci,
+  useControlMciNode,
+  type LifecycleAction,
+} from '@/entities/mci/api';
+import { toErrorMessage } from '@/shared/utils';
+
+/**
+ * Workload lifecycle control — the rules, in one place.
+ *
+ * Suspend / Resume / Reboot / Terminate all go to cb-tumblebug's control endpoint. What differs
+ * between them is *when they are allowed* and *how much damage they do*, and both of those have to
+ * be on screen before the user commits. Keeping them here means the infra list and the server list
+ * cannot drift into describing the same action two different ways.
+ */
+
+/** Whether the action applies to a whole workload or to one server inside it. */
+export type LifecycleScope = 'infra' | 'node';
+
+export interface ILifecycleActionMeta {
+  name: LifecycleAction;
+  label: string;
+  /** Typing the target name is required before this can run. */
+  destructive: boolean;
+  /**
+   * Statuses cb-tumblebug will accept this action from (its CheckAllowedTransition).
+   *
+   * Used only to *warn* — the request is never blocked on it. The server is the authority, and a
+   * status we read a moment ago may already be stale.
+   */
+  allowedFrom: string[];
+  /** One line saying what actually happens, shown in the confirm step. */
+  describe: (scope: LifecycleScope) => string;
+}
+
+export const LIFECYCLE_ACTIONS: Record<LifecycleAction, ILifecycleActionMeta> =
+  {
+    suspend: {
+      name: 'suspend',
+      label: 'Suspend',
+      destructive: false,
+      allowedFrom: ['running'],
+      describe: scope =>
+        scope === 'infra'
+          ? 'Stops every server in the selected workloads. Nothing is deleted, and Resume starts them again.'
+          : 'Stops the selected server. Nothing is deleted, and Resume starts it again.',
+    },
+    resume: {
+      name: 'resume',
+      label: 'Resume',
+      destructive: false,
+      allowedFrom: ['suspended'],
+      describe: scope =>
+        scope === 'infra'
+          ? 'Starts every suspended server in the selected workloads again.'
+          : 'Starts the selected server again.',
+    },
+    reboot: {
+      name: 'reboot',
+      label: 'Reboot',
+      destructive: false,
+      allowedFrom: ['running'],
+      describe: scope =>
+        scope === 'infra'
+          ? 'Restarts every server in the selected workloads. Anything running on them is interrupted.'
+          : 'Restarts the selected server. Anything running on it is interrupted.',
+    },
+    terminate: {
+      name: 'terminate',
+      label: 'Terminate',
+      destructive: true,
+      // Terminating something already terminated is accepted as a no-op, so it belongs here too.
+      allowedFrom: ['running', 'suspended', 'terminated'],
+      describe: scope =>
+        scope === 'infra'
+          ? 'Destroys every server in the selected workloads at the cloud provider. They cannot be brought back. The workload entry itself remains until you delete it.'
+          : 'Destroys the selected server at the cloud provider. It cannot be brought back.',
+    },
+  };
+
+/** The order the actions appear in the menu — least to most damaging. */
+export const LIFECYCLE_ACTION_ORDER: LifecycleAction[] = [
+  'suspend',
+  'resume',
+  'reboot',
+  'terminate',
+];
+
+/**
+ * The bare status word.
+ *
+ * A workload's status arrives decorated — `Running:1 (R:1/1)` — while a server's is the plain word.
+ * Both reduce to the same first token, which is all the transition rules care about.
+ */
+export function statusWord(status?: string): string {
+  if (!status) return '';
+  return (status.split(/[:\s(]/)[0] ?? '').trim().toLowerCase();
+}
+
+/**
+ * Whether cb-tumblebug is likely to accept this action from the target's current status.
+ *
+ * An unknown status answers `true` — not knowing is not the same as knowing it is wrong, and a
+ * warning shown on every row would soon be ignored on the rows that matter.
+ */
+export function isTransitionAllowed(
+  action: LifecycleAction,
+  status?: string,
+): boolean {
+  const word = statusWord(status);
+  if (!word) return true;
+  return LIFECYCLE_ACTIONS[action].allowedFrom.includes(word);
+}
+
+/** Statuses that mean the target is mid-transition; the list keeps watching while any remain. */
+const TRANSITIONAL = [
+  'creating',
+  'terminating',
+  'resuming',
+  'suspending',
+  'rebooting',
+];
+
+export function isTransitioning(
+  status?: string,
+  targetAction?: string,
+): boolean {
+  if (TRANSITIONAL.includes(statusWord(status))) return true;
+  // cb-tumblebug clears targetAction to `Complete` when it is finished with the infra.
+  return !!targetAction && targetAction !== 'Complete';
+}
+
+export interface ILifecycleTarget {
+  /** The id the API is called with. For workloads this is the infra id, for servers the node id. */
+  id: string;
+  /** What the user sees, and what a destructive action asks them to type. */
+  name: string;
+  status?: string;
+}
+
+export type LifecycleOutcome = 'pending' | 'accepted' | 'failed';
+
+export interface ILifecycleResult {
+  id: string;
+  name: string;
+  outcome: LifecycleOutcome;
+  /** The server's own words — its acknowledgement, or its reason for refusing. */
+  message: string;
+}
+
+export interface ILifecycleRunOptions {
+  scope: LifecycleScope;
+  nsId: string;
+  /** Required for `node` scope — the workload the servers belong to. */
+  infraId?: string;
+  action: LifecycleAction;
+  force: boolean;
+  targets: ILifecycleTarget[];
+}
+
+export function useLifecycleControl() {
+  const state = reactive({
+    results: [] as ILifecycleResult[],
+    running: false,
+  });
+
+  function reset() {
+    state.results = [];
+    state.running = false;
+  }
+
+  /**
+   * Send the action for each target and record what came back, one by one.
+   *
+   * **Sequential on purpose.** Firing them together is what broke the workload list once already:
+   * cb-tumblebug turns away lookups past the second in flight, and a `Promise.all` threw away the
+   * successful answers along with the rejected one. A handful of selected workloads costs
+   * nothing to walk in order, and each one's outcome lands on screen as it arrives instead of all of
+   * them appearing at the end.
+   *
+   * A failure never stops the rest — one workload refusing the action says nothing about the others.
+   */
+  async function run(
+    options: ILifecycleRunOptions,
+  ): Promise<ILifecycleResult[]> {
+    const { scope, nsId, infraId, action, force, targets } = options;
+    state.running = true;
+    state.results = targets.map(t => ({
+      id: t.id,
+      name: t.name,
+      outcome: 'pending' as LifecycleOutcome,
+      message: '',
+    }));
+
+    for (const [index, target] of targets.entries()) {
+      const request =
+        scope === 'node'
+          ? useControlMciNode({
+              nsId,
+              infraId: infraId ?? '',
+              nodeId: target.id,
+              action,
+              force,
+            })
+          : useControlMci({ nsId, infraId: target.id, action, force });
+
+      let outcome: LifecycleOutcome;
+      let message: string;
+      try {
+        const res = await request.execute();
+        outcome = 'accepted';
+        // cb-tumblebug replies with a line such as "Suspending the Infra". It is an acknowledgement,
+        // not a completion, so it is shown as-is rather than rewritten into "Done".
+        message = res?.data?.responseData?.message ?? 'Request accepted.';
+      } catch (e) {
+        outcome = 'failed';
+        // Refusals here are usually the server saying the status does not allow it — the exact
+        // sentence is the useful part, so it is passed through untouched.
+        message = toErrorMessage(
+          e,
+          'The request was refused and no reason was given.',
+        );
+      }
+
+      // The modal can be dismissed while this loop is still walking the targets, and closing clears
+      // the results. Writing into a row that is no longer there would throw and lose the outcomes
+      // of every target after it, so a vanished row is simply skipped.
+      const slot = state.results[index];
+      if (!slot || slot.id !== target.id) continue;
+      slot.outcome = outcome;
+      slot.message = message;
+    }
+
+    state.running = false;
+    return state.results;
+  }
+
+  return { state, run, reset };
+}

--- a/front/src/features/workload/lifecycleControl/ui/LifecycleControlModal.vue
+++ b/front/src/features/workload/lifecycleControl/ui/LifecycleControlModal.vue
@@ -1,0 +1,540 @@
+<script setup lang="ts">
+import {
+  PButtonModal,
+  PButton,
+  PFieldGroup,
+  PRadio,
+  PRadioGroup,
+  PTextInput,
+} from '@cloudforet-test/mirinae';
+import { computed, reactive, watch } from 'vue';
+import type { LifecycleAction } from '@/entities/mci/api';
+import {
+  LIFECYCLE_ACTIONS,
+  isTransitionAllowed,
+  useLifecycleControl,
+  type ILifecycleTarget,
+  type LifecycleScope,
+} from '@/features/workload/lifecycleControl/model';
+
+interface IProps {
+  visible: boolean;
+  /** null while the modal is closed — nothing is drawn until an action is chosen. */
+  action: LifecycleAction | null;
+  scope: LifecycleScope;
+  nsId: string;
+  /** The workload the servers belong to. Only used for `node` scope. */
+  infraId?: string;
+  targets: ILifecycleTarget[];
+}
+
+interface IEmits {
+  (e: 'update:visible', value: boolean): void;
+  /** The requests went out. The caller refreshes and follows the status from here. */
+  (e: 'requested'): void;
+}
+
+const props = defineProps<IProps>();
+const emit = defineEmits<IEmits>();
+
+const { state: runState, run, reset: resetRun } = useLifecycleControl();
+
+const state = reactive({
+  // confirm  — what it does, which targets, normal or force, and (destructive only) the typed name
+  // progress — one row per target: requesting, accepted, or refused with the reason
+  phase: 'confirm' as 'confirm' | 'progress',
+  method: 'normal' as 'normal' | 'force',
+  confirmKeyword: '',
+});
+
+const meta = computed(() =>
+  props.action ? LIFECYCLE_ACTIONS[props.action] : null,
+);
+
+const scopeNoun = computed(() =>
+  props.scope === 'infra'
+    ? props.targets.length === 1
+      ? 'Workload'
+      : 'Workloads'
+    : props.targets.length === 1
+      ? 'Server'
+      : 'Servers',
+);
+
+const headerTitle = computed(() =>
+  meta.value ? `${meta.value.label} ${scopeNoun.value}` : '',
+);
+
+/** What a destructive action asks the user to type — the name itself, or a phrase for a batch. */
+const checkKeyword = computed(() => {
+  if (props.targets.length === 1) return props.targets[0]?.name ?? '';
+  return `${meta.value?.label ?? ''} All`;
+});
+
+/** Targets whose current status is not one this action normally runs from. */
+const blockedTargets = computed(() =>
+  props.action
+    ? props.targets.filter(t => !isTransitionAllowed(props.action!, t.status))
+    : [],
+);
+
+/**
+ * The warning shown when a target's status is not one this action normally runs from.
+ *
+ * Worded for how many there are. A single target reads as itself — "1 of 1 are not in a state…"
+ * counts something the user can already see, and gets the grammar wrong on the way.
+ */
+const stateWarning = computed(() => {
+  if (!meta.value || !blockedTargets.value.length) return '';
+  const noun = props.scope === 'infra' ? 'workload' : 'server';
+  const subject =
+    props.targets.length === 1
+      ? `This ${noun} is`
+      : blockedTargets.value.length === props.targets.length
+        ? `None of the selected ${noun}s are`
+        : `${blockedTargets.value.length} of the ${props.targets.length} selected ${noun}s are`;
+  return `${subject} not in a state that normally allows ${meta.value.label}. The request may be refused — Force sends it regardless.`;
+});
+
+const isConfirmDisabled = computed(() => {
+  if (state.phase === 'progress') return true;
+  if (!props.targets.length) return true;
+  if (!meta.value?.destructive) return false;
+  return state.confirmKeyword !== checkKeyword.value;
+});
+
+const anyFailed = computed(() =>
+  runState.results.some(r => r.outcome === 'failed'),
+);
+const allSettled = computed(
+  () =>
+    runState.results.length > 0 &&
+    runState.results.every(r => r.outcome !== 'pending'),
+);
+
+/**
+ * Offer force only where it would change the answer.
+ *
+ * Force skips cb-tumblebug's state checks, so it helps when the refusal was a state check and does
+ * nothing at all when it was not. Showing it after a run that already used force would just invite
+ * pressing the same button twice.
+ */
+const canRetryWithForce = computed(
+  () => allSettled.value && anyFailed.value && state.method !== 'force',
+);
+
+async function fire(force: boolean) {
+  if (!props.action) return;
+  state.phase = 'progress';
+  await run({
+    scope: props.scope,
+    nsId: props.nsId,
+    infraId: props.infraId,
+    action: props.action,
+    force,
+    targets: props.targets,
+  });
+  // Told as soon as the requests are answered, whatever the answers were. Even a partial success
+  // has started a transition, and the list is where that transition becomes visible.
+  emit('requested');
+
+  // Nothing refused it — the remaining story is the status changing, which the list tells better
+  // than a dialog holding an acknowledgement line.
+  if (!anyFailed.value) closeAndReset();
+}
+
+function handleConfirm() {
+  if (state.phase !== 'confirm' || isConfirmDisabled.value) return;
+  void fire(state.method === 'force');
+}
+
+function handleForceRetry() {
+  state.method = 'force';
+  void fire(true);
+}
+
+function closeAndReset() {
+  emit('update:visible', false);
+  resetState();
+}
+
+function resetState() {
+  state.phase = 'confirm';
+  state.method = 'normal';
+  state.confirmKeyword = '';
+  resetRun();
+}
+
+// Guarded as well as disabled: mirinae's disabled is a class only, and the click still reaches the
+// handler (DESIGN-MIRINAE §1.6). Closing mid-run would drop the outcomes still on their way back.
+function handleClose() {
+  if (runState.running) return;
+  closeAndReset();
+}
+
+watch(
+  () => props.visible,
+  visible => {
+    if (!visible) resetState();
+  },
+);
+</script>
+
+<template>
+  <p-button-modal
+    data-testid="wl-lifecycle-modal"
+    :visible="visible"
+    :header-title="headerTitle"
+    size="sm"
+    hide-footer
+    @close="handleClose"
+    @update:visible="$emit('update:visible', $event)"
+  >
+    <template #body>
+      <div v-if="meta" class="lifecycle-modal-content" :data-action="meta.name">
+        <!-- progress step — one row per target, with whatever the server said -->
+        <div
+          v-if="state.phase === 'progress'"
+          data-testid="wl-lifecycle-progress"
+        >
+          <p class="description">
+            {{ meta.label }} requested for the following
+            {{ scopeNoun.toLowerCase() }}
+          </p>
+          <div class="target-list">
+            <div
+              v-for="result in runState.results"
+              :key="result.id"
+              class="result-item"
+              data-testid="wl-lifecycle-result"
+              :data-name="result.name"
+              :data-outcome="result.outcome"
+            >
+              <span class="target-name">{{ result.name }}</span>
+              <span
+                v-if="result.outcome === 'pending'"
+                class="result-status pending"
+              >
+                <span class="spinner" /> Requesting
+              </span>
+              <span
+                v-else-if="result.outcome === 'failed'"
+                class="result-status failed"
+                >Refused</span
+              >
+              <span v-else class="result-status accepted">Accepted</span>
+            </div>
+          </div>
+
+          <!-- Refusals are usually the server saying the status does not allow it. The sentence is
+               the useful part, so it is shown in full rather than summarised away. -->
+          <div
+            v-if="anyFailed"
+            class="reason-box"
+            data-testid="wl-lifecycle-error"
+          >
+            <div
+              v-for="result in runState.results.filter(
+                r => r.outcome === 'failed',
+              )"
+              :key="`reason-${result.id}`"
+              class="reason-item"
+            >
+              <span class="target-name">{{ result.name }}</span>
+              <span class="reason-text">{{ result.message }}</span>
+            </div>
+          </div>
+          <p v-if="canRetryWithForce" class="hint">
+            Force skips the status checks and sends the same action anyway. It
+            removes nothing and leaves no cloud resources behind.
+          </p>
+        </div>
+
+        <!-- confirm step — what it does, on what, and how -->
+        <div v-else data-testid="wl-lifecycle-confirm">
+          <div
+            :class="[
+              'action-banner',
+              meta.destructive ? 'destructive' : 'neutral',
+            ]"
+          >
+            {{ meta.describe(scope) }}
+          </div>
+
+          <p class="description">
+            The following {{ scopeNoun.toLowerCase() }} will be affected
+          </p>
+          <div class="target-list">
+            <div
+              v-for="target in targets"
+              :key="target.id"
+              class="target-item"
+              data-testid="wl-lifecycle-target"
+              :data-name="target.name"
+              :data-status="target.status ?? ''"
+              :data-allowed="
+                String(isTransitionAllowed(meta.name, target.status))
+              "
+            >
+              <span class="target-name">{{ target.name }}</span>
+              <span class="target-status">{{
+                target.status || 'Unknown'
+              }}</span>
+            </div>
+          </div>
+
+          <!-- Said before the request goes out, not after it comes back refused. The action is not
+               blocked on it — the status on screen may already be out of date, and the server is the
+               one that decides. -->
+          <p
+            v-if="blockedTargets.length"
+            class="warning-note"
+            data-testid="wl-lifecycle-state-warning"
+          >
+            {{ stateWarning }}
+          </p>
+
+          <p-field-group label="Method" required class="mt-8">
+            <div v-if="state.method === 'force'" class="force-note">
+              Force skips the checks for "another action is already running" and
+              "this transition is not allowed from the current status". It
+              deletes nothing and leaves no cloud resources behind.
+            </div>
+            <p-radio-group>
+              <p-radio
+                v-model="state.method"
+                value="normal"
+                data-testid="wl-lifecycle-method-normal"
+              >
+                <span>Normal</span>
+              </p-radio>
+              <p-radio
+                v-model="state.method"
+                value="force"
+                data-testid="wl-lifecycle-method-force"
+              >
+                <span>Force</span>
+              </p-radio>
+            </p-radio-group>
+          </p-field-group>
+
+          <p-field-group v-if="meta.destructive" required class="mt-8">
+            <template #label>
+              <span
+                >To continue, please enter
+                <span class="keyword-highlight">{{ checkKeyword }}</span></span
+              >
+              <p-text-input
+                v-model="state.confirmKeyword"
+                data-testid="wl-lifecycle-confirm-keyword"
+                :placeholder="checkKeyword"
+              />
+            </template>
+          </p-field-group>
+        </div>
+
+        <!--
+          ★ PButtonModal has no `footer` slot — the footer is a fixed area behind `v-if="!hideFooter"`
+            and only its close/confirm slots can be replaced. With `hide-footer` set, the buttons are
+            drawn at the end of the body instead (DESIGN-MIRINAE §1.1).
+        -->
+        <div class="modal-footer">
+          <template v-if="state.phase === 'progress'">
+            <p-button
+              style-type="transparent"
+              data-testid="wl-lifecycle-close"
+              :disabled="runState.running"
+              @click="handleClose"
+            >
+              Close
+            </p-button>
+            <p-button
+              v-if="canRetryWithForce"
+              style-type="secondary"
+              data-testid="wl-lifecycle-force-retry"
+              @click="handleForceRetry"
+            >
+              Retry with Force
+            </p-button>
+          </template>
+          <template v-else>
+            <p-button
+              style-type="transparent"
+              data-testid="wl-lifecycle-cancel"
+              @click="handleClose"
+            >
+              Cancel
+            </p-button>
+            <p-button
+              :style-type="meta.destructive ? 'negative-primary' : 'primary'"
+              data-testid="wl-lifecycle-ok"
+              :disabled="isConfirmDisabled"
+              @click="handleConfirm"
+            >
+              {{ meta.label }}
+            </p-button>
+          </template>
+        </div>
+      </div>
+    </template>
+  </p-button-modal>
+</template>
+
+<style scoped lang="postcss">
+.lifecycle-modal-content {
+  .action-banner {
+    padding: 12px;
+    margin-bottom: 16px;
+    border-radius: 4px;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+  .action-banner.neutral {
+    background-color: #eef2ff;
+    border: 1px solid #c7d2fe;
+    color: #3730a3;
+  }
+  .action-banner.destructive {
+    background-color: #fee;
+    border: 1px solid #e53e3e;
+    color: #c53030;
+  }
+
+  .description {
+    font-size: 14px;
+    margin-bottom: 4px;
+  }
+
+  .target-list {
+    padding: 12px;
+    background-color: #f7f7f7;
+    border-radius: 4px;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .target-item,
+  .result-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 0;
+    font-size: 14px;
+  }
+
+  .target-name {
+    font-family: monospace;
+  }
+
+  .target-status {
+    font-size: 0.8125rem;
+    color: #6b7280;
+  }
+
+  .result-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+  }
+  .result-status.pending {
+    color: #6b7280;
+  }
+  .result-status.accepted {
+    color: #2a9d8f;
+  }
+  .result-status.failed {
+    color: #dc2626;
+    font-weight: 600;
+  }
+  .result-status .spinner {
+    width: 12px;
+    height: 12px;
+    border: 2px solid #d1d5db;
+    border-top-color: #6b7280;
+    border-radius: 50%;
+    animation: wl-lifecycle-spin 0.8s linear infinite;
+  }
+
+  .warning-note {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background-color: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    color: #856404;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .force-note {
+    padding: 12px;
+    margin-bottom: 8px;
+    background-color: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    color: #856404;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  /* A long reason stays in a scroll area so it cannot push the buttons out of reach. */
+  .reason-box {
+    margin-top: 12px;
+    max-height: 180px;
+    overflow-y: auto;
+    padding: 12px;
+    background-color: #fff5f5;
+    border: 1px solid #feb2b2;
+    border-radius: 4px;
+  }
+  .reason-item {
+    padding: 6px 0;
+    font-size: 13px;
+  }
+  .reason-item + .reason-item {
+    border-top: 1px solid #fed7d7;
+  }
+  .reason-item .target-name {
+    display: block;
+    font-weight: 600;
+    color: #c53030;
+  }
+  .reason-text {
+    display: block;
+    margin-top: 2px;
+    color: #742a2a;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .hint {
+    margin-top: 10px;
+    font-size: 12px;
+    color: #6b7280;
+    line-height: 1.5;
+  }
+
+  .keyword-highlight {
+    color: #e53e3e;
+    font-weight: bold;
+  }
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  /* Drawn inside the body with the default footer off, so a rule and spacing make it read as one. */
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+@keyframes wl-lifecycle-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/front/src/widgets/workload/mci/mciList/model/index.ts
+++ b/front/src/widgets/workload/mci/mciList/model/index.ts
@@ -5,6 +5,8 @@ import { IMci, McisTableType, useMCIStore } from '@/entities/mci/model';
 import { useGetMciList } from '@/entities/mci/api';
 import { getCloudProvidersInVms } from '@/shared/hooks/vm';
 import { showErrorMessage, toErrorMessage } from '@/shared/utils';
+import { isTransitioning } from '@/features/workload/lifecycleControl/model';
+import { registerPoller } from '@/shared/libs/polling';
 
 interface IProps {
   nsId: string;
@@ -86,9 +88,16 @@ export function useMciListModel(props: IProps) {
     return organizedDatum;
   }
 
-  function fetchMciList() {
-    loading.value = true;
-    resMciList
+  /**
+   * Fetch the list.
+   *
+   * `quiet` leaves the loading flag alone. The flag swaps the table for a spinner, which is right
+   * for the first load and wrong for a background re-check — the table would blink away every few
+   * seconds while a workload is suspending.
+   */
+  function fetchMciList(options?: { quiet?: boolean }) {
+    if (!options?.quiet) loading.value = true;
+    return resMciList
       .execute()
       .then(res => {
         if (res.data.responseData) {
@@ -112,6 +121,13 @@ export function useMciListModel(props: IProps) {
         }
       })
       .catch(e => {
+        // A background re-check that fails leaves the previous rows and the status the user is
+        // already looking at. Raising a toast for it every few seconds would bury the notifications
+        // that matter, so it is logged and the watch below gives up on its own deadline.
+        if (options?.quiet) {
+          console.warn('background refresh of the infra list failed', e);
+          return;
+        }
         // The lookup is shared: the rate limit is counted per caller, and to cb-tumblebug the
         // caller is always cm-beetle — so other users and other tabs draw from the same budget.
         // Being turned away is not a broken list, and saying so keeps the user from hunting a
@@ -124,8 +140,67 @@ export function useMciListModel(props: IProps) {
         );
       })
       .finally(() => {
-        loading.value = false;
+        if (!options?.quiet) loading.value = false;
       });
+  }
+
+  // ── Following a lifecycle action ───────────────────────────────────────────
+  //
+  // A control request is answered before the work is done — cb-tumblebug says "Suspending the Infra"
+  // while the provider is still stopping the servers. Left alone, the list would keep showing the
+  // status from before the action and the screen would look as though nothing had happened.
+  //
+  // ★ The list, and only the list. Asking each workload for its own detail is exactly the fan-out
+  //   that broke this screen once: cb-tumblebug allows two infra lookups at a time, so
+  //   from the third workload on the extra calls came back 429 and took the whole list with them.
+  //   One list call already carries every status shown here.
+  const FOLLOW_INTERVAL_MS = 5_000;
+  const FOLLOW_TIMEOUT_MS = 3 * 60_000;
+  let followTimer: ReturnType<typeof setTimeout> | null = null;
+  let unregisterFollowPoller: (() => void) | null = null;
+
+  function stopFollowing() {
+    if (followTimer) {
+      clearTimeout(followTimer);
+      followTimer = null;
+    }
+    unregisterFollowPoller?.();
+    unregisterFollowPoller = null;
+  }
+
+  /** Whether any of the named workloads is still mid-transition, per the list we last received. */
+  function anyTransitioning(infraIds: string[]): boolean {
+    return mcis.value.some(
+      mci =>
+        infraIds.includes(mci.id) &&
+        isTransitioning(mci.status, mci.targetAction),
+    );
+  }
+
+  /**
+   * Re-read the list until the given workloads have settled, or until the deadline.
+   *
+   * The deadline is there because a transition can also end by getting stuck; polling for ever would
+   * keep calling the API long after anyone stopped watching. Registering with the poller registry is
+   * what makes a session ending stop this too — otherwise it keeps calling after logout, gets a 401,
+   * and drops the user back onto the "session expired" path.
+   */
+  function followTransition(infraIds: string[]) {
+    if (!infraIds.length) return;
+    stopFollowing();
+    unregisterFollowPoller = registerPoller(stopFollowing);
+    const deadline = Date.now() + FOLLOW_TIMEOUT_MS;
+
+    const tick = async () => {
+      await fetchMciList({ quiet: true });
+      if (Date.now() > deadline || !anyTransitioning(infraIds)) {
+        stopFollowing();
+        return;
+      }
+      followTimer = setTimeout(() => void tick(), FOLLOW_INTERVAL_MS);
+    };
+
+    followTimer = setTimeout(() => void tick(), FOLLOW_INTERVAL_MS);
   }
 
   watch(
@@ -144,6 +219,8 @@ export function useMciListModel(props: IProps) {
     initToolBoxTableModel,
     mciStore,
     fetchMciList,
+    followTransition,
+    stopFollowing,
     resMciList,
     loading,
   };

--- a/front/src/widgets/workload/mci/mciList/ui/MciList.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciList.vue
@@ -10,13 +10,20 @@ import {
 import {
   onBeforeMount,
   onMounted,
-  onUnmounted,
+  onBeforeUnmount,
   reactive,
   computed,
   ref,
   watch,
 } from 'vue';
 import MciDeleteModal from './MciDeleteModal.vue';
+import LifecycleControlModal from '@/features/workload/lifecycleControl/ui/LifecycleControlModal.vue';
+import {
+  LIFECYCLE_ACTIONS,
+  LIFECYCLE_ACTION_ORDER,
+  type ILifecycleTarget,
+} from '@/features/workload/lifecycleControl/model';
+import type { LifecycleAction } from '@/entities/mci/api';
 import TableLoadingSpinner from '@/shared/ui/LoadingSpinner/TableLoadingSpinner.vue';
 import { useDynamicTableHeight } from '@/shared/hooks/table/useDynamicTableHeight';
 import { useToolboxTableHeight } from '@/shared/hooks/table/useToolboxTableHeight';
@@ -33,8 +40,14 @@ interface IProps {
 const props = defineProps<IProps>();
 const emit = defineEmits(['selectRow']);
 
-const { mciTableModel, initToolBoxTableModel, fetchMciList, loading } =
-  useMciListModel(props);
+const {
+  mciTableModel,
+  initToolBoxTableModel,
+  fetchMciList,
+  followTransition,
+  stopFollowing,
+  loading,
+} = useMciListModel(props);
 
 const { dynamicHeight, minHeight, maxHeight } = useDynamicTableHeight(
   computed(() => mciTableModel.tableState.items.length),
@@ -56,8 +69,16 @@ const isActionDisabled = computed(() => {
   return mciTableModel.tableState.selectIndex.length === 0;
 });
 
+// Lifecycle first, then a rule, then Delete. Delete is the one that cannot be undone and the one
+// that was here before, so it keeps its place at the bottom rather than sitting among the others.
 const actionState = reactive({
   actionMenus: computed(() => [
+    ...LIFECYCLE_ACTION_ORDER.map(action => ({
+      name: action,
+      label: LIFECYCLE_ACTIONS[action].label,
+      disabled: isActionDisabled.value,
+    })),
+    { type: 'divider' },
     { name: 'delete', label: 'Delete', disabled: isActionDisabled.value },
   ]),
   selectedActionItem: '',
@@ -67,15 +88,39 @@ const deleteModalState = reactive({
   visible: false,
 });
 
+const lifecycleModalState = reactive({
+  visible: false,
+  action: null as LifecycleAction | null,
+});
+
 const selectedMciList = computed(() => {
   return mciTableModel.tableState.selectIndex.map(index => {
     return mciTableModel.tableState.displayItems[index];
   });
 });
 
-function handleDelete(item: string) {
+/**
+ * The selected rows as lifecycle targets.
+ *
+ * In cb-tumblebug an infra's id *is* its name, but the two are read from different fields and the
+ * one the API needs is the id — falling back to the name only when the row has no id.
+ */
+const lifecycleTargets = computed<ILifecycleTarget[]>(() =>
+  selectedMciList.value.map(item => ({
+    id: item?.id ?? item?.name ?? '',
+    name: item?.name ?? '',
+    status: item?.status,
+  })),
+);
+
+function handleAction(item: string) {
   if (item === 'delete') {
     deleteModalState.visible = true;
+    return;
+  }
+  if (LIFECYCLE_ACTION_ORDER.includes(item as LifecycleAction)) {
+    lifecycleModalState.action = item as LifecycleAction;
+    lifecycleModalState.visible = true;
   }
 }
 
@@ -83,6 +128,20 @@ async function handleDeleted() {
   await fetchMciList();
   // re-render once the data has loaded
   tableKey.value++;
+}
+
+/**
+ * The action was accepted — now show it happening.
+ *
+ * Refresh once so the workload flips to Suspending/Rebooting straight away, then keep re-reading
+ * the list until it settles. Without that second part the row would sit on the transitional status
+ * for ever and read as stuck.
+ */
+async function handleLifecycleRequested() {
+  const ids = lifecycleTargets.value.map(t => t.id).filter(Boolean);
+  await fetchMciList();
+  tableKey.value++;
+  followTransition(ids);
 }
 
 function handleSelectedIndex(index: number[]) {
@@ -145,6 +204,11 @@ onMounted(async () => {
   // re-render after the initial data load
   tableKey.value++;
 });
+
+// Leaving the screen ends the transition watch. It only exists to keep *this* list honest.
+onBeforeUnmount(() => {
+  stopFollowing();
+});
 </script>
 
 <template>
@@ -178,7 +242,7 @@ onMounted(async () => {
           :select-index.sync="mciTableModel.tableState.selectIndex"
           :page-size="mciTableModel.tableOptions.pageSize"
           @change="mciTableModel.handleChange"
-          @refresh="fetchMciList"
+          @refresh="() => fetchMciList()"
           @select="handleSelectedIndex"
         >
           <template #toolbox-left>
@@ -189,8 +253,22 @@ onMounted(async () => {
               :selected.sync="actionState.selectedActionItem"
               reset-selected-on-unmounted
               class="mr-2"
-              @select="handleDelete"
-            />
+              @select="handleAction"
+            >
+              <!--
+                Identifiers for the menu items.
+
+                mirinae's PContextMenu copies only the props it knows from each menu entry, so a
+                data-testid put on the entry object is dropped without a word. Drawing the label
+                through this slot is the way to attach one. The slot must always render an element
+                (DESIGN-MIRINAE §1.7).
+              -->
+              <template #menu-item--format="{ item }">
+                <span :data-testid="`mci-action-${item.name}`">{{
+                  item.label
+                }}</span>
+              </template>
+            </p-select-dropdown>
             <p-button
               style-type="primary"
               icon-left="ic_plus_bold"
@@ -249,6 +327,14 @@ onMounted(async () => {
       :selected-mci-list="selectedMciList"
       :ns-id="nsId"
       @deleted="handleDeleted"
+    />
+    <lifecycle-control-modal
+      :visible.sync="lifecycleModalState.visible"
+      :action="lifecycleModalState.action"
+      scope="infra"
+      :ns-id="nsId"
+      :targets="lifecycleTargets"
+      @requested="handleLifecycleRequested"
     />
   </div>
 </template>

--- a/front/src/widgets/workload/vm/vmList/ui/VmList.vue
+++ b/front/src/widgets/workload/vm/vmList/ui/VmList.vue
@@ -2,6 +2,7 @@
 import {
   PButton,
   PSelectCard,
+  PSelectDropdown,
   PToolbox,
   PDataLoader,
   PButtonTab,
@@ -30,7 +31,15 @@ import {
   useGetLoadTestInfo,
 } from '@/entities/vm/api/api';
 import { useGetMciInfo } from '@/entities/mci/api';
+import type { LifecycleAction } from '@/entities/mci/api';
 import { ILoadConfigInitialValues } from '@/features/workload/actionLoadConfig/model';
+import LifecycleControlModal from '@/features/workload/lifecycleControl/ui/LifecycleControlModal.vue';
+import {
+  LIFECYCLE_ACTIONS,
+  LIFECYCLE_ACTION_ORDER,
+  isTransitioning,
+  type ILifecycleTarget,
+} from '@/features/workload/lifecycleControl/model';
 
 interface IProps {
   nsId: string;
@@ -273,6 +282,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   stopLoadStatusPolling();
+  stopNodeFollow();
   unregisterPoller?.();
 });
 
@@ -443,6 +453,119 @@ function handleLoadConfigRequestSuccess(
   setVmLoadTestResult();
 }
 
+// ── Server lifecycle control (Suspend / Resume / Reboot / Terminate) ────────
+//
+// The same four actions the workload list offers, aimed at one server instead of all of them. The
+// action menu is disabled until a server is selected — with nothing selected there is no target, and
+// acting on "whichever one is first" is not something a console should decide for the user.
+
+const lifecycleModalState = reactive({
+  visible: false,
+  action: null as LifecycleAction | null,
+});
+
+// Holds which menu entry is highlighted; the work is driven by the select event, not by this.
+const nodeActionState = reactive({
+  selectedActionItem: '',
+});
+
+const isNodeActionDisabled = computed(() => !selectedVm.value);
+
+const nodeActionMenus = computed(() =>
+  LIFECYCLE_ACTION_ORDER.map(action => ({
+    name: action,
+    label: LIFECYCLE_ACTIONS[action].label,
+    disabled: isNodeActionDisabled.value,
+  })),
+);
+
+const nodeLifecycleTargets = computed<ILifecycleTarget[]>(() =>
+  selectedVm.value
+    ? [
+        {
+          id: selectedVm.value.id,
+          name: selectedVm.value.name || selectedVm.value.id,
+          status: selectedVm.value.status,
+        },
+      ]
+    : [],
+);
+
+function handleNodeAction(item: string) {
+  if (!selectedVm.value) return;
+  if (!LIFECYCLE_ACTION_ORDER.includes(item as LifecycleAction)) return;
+  lifecycleModalState.action = item as LifecycleAction;
+  lifecycleModalState.visible = true;
+}
+
+// Bumped to remount the node detail, which reads its values on mount. Without it the detail keeps
+// showing the status from before the action even after the infra has been re-read.
+const nodeDetailKey = ref(0);
+
+let nodeFollowTimer: ReturnType<typeof setTimeout> | null = null;
+let unregisterNodeFollowPoller: (() => void) | null = null;
+
+function stopNodeFollow() {
+  if (nodeFollowTimer) {
+    clearTimeout(nodeFollowTimer);
+    nodeFollowTimer = null;
+  }
+  unregisterNodeFollowPoller?.();
+  unregisterNodeFollowPoller = null;
+}
+
+/**
+ * Re-read the workload and point the screen at the *fresh* copy of the selected server.
+ *
+ * Re-reading alone is not enough. The store merges the new workload over the old one, which replaces
+ * its server array, so the object this screen is holding is left behind — detached from the store
+ * and frozen at the status it had before the action. Looking the server up again by id is what keeps
+ * the detail showing the truth.
+ */
+async function refreshSelectedNode() {
+  const nodeId = selectedVm.value?.id;
+  if (!nodeId) return;
+  await getMciInfo();
+  const fresh = mciStore
+    .getMciById(props.mciId)
+    ?.vm?.find(vm => vm.id === nodeId);
+  if (fresh) selectedVm.value = fresh;
+  nodeDetailKey.value++;
+}
+
+/**
+ * Watch the selected server until it settles.
+ *
+ * cb-tumblebug answers the control call while the provider is still working, so a single refresh
+ * would only ever catch `Suspending`. Registering with the poller registry is what stops this when
+ * the session ends — a poll left running after logout gets a 401 and throws the user back onto the
+ * "session expired" path.
+ */
+function followNodeTransition() {
+  stopNodeFollow();
+  unregisterNodeFollowPoller = registerPoller(stopNodeFollow);
+  const deadline = Date.now() + 3 * 60_000;
+
+  const tick = async () => {
+    await refreshSelectedNode();
+    if (
+      Date.now() > deadline ||
+      !isTransitioning(selectedVm.value?.status, selectedVm.value?.targetAction)
+    ) {
+      stopNodeFollow();
+      return;
+    }
+    nodeFollowTimer = setTimeout(() => void tick(), 5_000);
+  };
+
+  nodeFollowTimer = setTimeout(() => void tick(), 5_000);
+}
+
+async function handleNodeLifecycleRequested() {
+  await refreshSelectedNode();
+  followNodeTransition();
+}
+
 function handleTemplateManagerOpen() {
   modalState.templateManagerRequest.open = true;
 }
@@ -470,6 +593,27 @@ function handleTemplateManagerClose() {
         @refresh="handleMciIdChange"
       >
         <template #left-area>
+          <p-select-dropdown
+            data-testid="vm-action-dropdown"
+            placeholder="Action"
+            :menu="nodeActionMenus"
+            :selected.sync="nodeActionState.selectedActionItem"
+            reset-selected-on-unmounted
+            class="mr-2"
+            @select="handleNodeAction"
+          >
+            <!--
+              mirinae's PContextMenu copies only the props it knows from each menu entry, so a
+              data-testid put on the entry object is dropped without a word. Drawing the label
+              through this slot is the way to attach one, and the slot must always render an
+              element (DESIGN-MIRINAE §1.7).
+            -->
+            <template #menu-item--format="{ item }">
+              <span :data-testid="`vm-action-${item.name}`">{{
+                item.label
+              }}</span>
+            </template>
+          </p-select-dropdown>
           <p-button
             style-type="tertiary"
             icon-left="ic_plus_bold"
@@ -516,6 +660,7 @@ function handleTemplateManagerClose() {
       >
         <template #information>
           <VmInformation
+            :key="nodeDetailKey"
             :mci-id="props.mciId"
             :ns-id="props.nsId"
             :vm-id="selectedVm.id"
@@ -587,6 +732,15 @@ function handleTemplateManagerClose() {
       :vm-id="selectedVm?.id ?? ''"
       :ip="selectedVm?.publicIP ?? ''"
       @close="handleTemplateManagerClose"
+    />
+    <lifecycle-control-modal
+      :visible.sync="lifecycleModalState.visible"
+      :action="lifecycleModalState.action"
+      scope="node"
+      :ns-id="props.nsId"
+      :infra-id="props.mciId"
+      :targets="nodeLifecycleTargets"
+      @requested="handleNodeLifecycleRequested"
     />
   </div>
 </template>


### PR DESCRIPTION
## What this adds

**Suspend · Resume · Reboot · Terminate** on the Infra Workloads screen, in two places:

| Where | Target | Call |
|---|---|---|
| Workload list toolbar `Action` | the selected workloads | `cb-tumblebug/GetControlInfra` |
| Server tab toolbar `Action` | the selected server | `cb-tumblebug/GetControlInfraNode` |

Until now the screen only offered deletion, so a migrated workload could not even be stopped for a while — saving cost meant destroying it and building it again.

## Why cb-tumblebug and not cm-beetle

Everything else on this screen goes through cm-beetle, so control would naturally go there too, but **cm-beetle has no such endpoint** — its infra surface is migrate, get, list and delete and nothing more. cm-beetle owns the *migration*; running what the migration produced stayed with cb-tumblebug. Both operationIds were already registered in `api.yaml`, so **no backend change was needed**.

## Design notes

**Force here is not the force of deletion.** It skips two state checks and removes nothing, leaving no cloud resources behind, so it carries its own wording rather than the delete warning.

**The reply is an acknowledgement, not a completion** (`Suspending the Infra`), so the list keeps re-reading until the workload settles — **the list only**. Asking each workload for its own detail is the fan-out that broke this screen before: cb-tumblebug allows two infra lookups at a time and the rest come back 429.

A state that does not allow the action is pointed out **before** the request goes out, but it does not block — the status on screen may already be stale and the server decides. Terminate cannot be undone, so it asks for the name to be typed. Requests go out one target at a time, and a refusal never stops the rest; the reason comes back in the server's own words.

## Verification

Driven from the console against a real workload, with the provider state checked at each step. All on the normal path, without Force.

| Action | Screen | Provider |
|---|---|---|
| Suspend | accepted | running → stopping → **stopped** |
| Resume | accepted | stopped → **running** |
| Terminate | blocked until the name is typed, then accepted | running → shutting-down → **terminated** |

Reboot was not measured against a live instance. It takes the same call path and the other three did move the provider, but it is stated here that it was not checked.