### PR TITLE
Improve the in-portal help for the JSON editor, and give screen elements stable identifiers

### DIFF
--- a/docs/guide/json-editor.md
+++ b/docs/guide/json-editor.md
@@ -98,14 +98,8 @@ document back.
 
 ## Filtering and reshaping an array
 
-The tree view has two more tools — **sort** and **transform**. They are powerful and they
-are also where people get stuck, because of one rule:
-
-> **They act on what you have selected.** Select nothing and they act on the whole
-> document, which is an object — and their wizard only works on arrays.
-
-That is why the fields you expected are missing: the editor is not looking at the array
-you had in mind.
+The tree view has two more tools — **sort** and **transform**. Both work on one array at a
+time, so **choose the array before you use them.**
 
 ### Select the array first
 
@@ -114,16 +108,17 @@ is highlighted. Then right-click it (or press `Ctrl+Q`).
 
 ![Selecting an array and opening its menu](images/json-05-select-context.png)
 
-**Sort** and **Transform** are now enabled, and they will act on that array.
+**Sort** and **Transform** are now enabled, and they act on the array you picked. The
+wizard offers that array's fields to filter, sort and pick by.
 
 ### The transform window
 
 ![The transform window with the wizard](images/json-06-transform-wizard.png)
 
-* **Path** shows what will be transformed. If it says `(document root)`, you did not
-  select an array — close the window, select one, and open it from the right-click menu
+* **Path** shows which array will be transformed. To work on a different one, close the
+  window, select that array, and open it from its right-click menu
 * **Wizard** builds the query for you: filter by a field, sort by a field, pick fields to
-  keep. It appears only when Path is an array
+  keep
 * **Query** is the same thing written out. The language is
   [JSON Query](https://jsonquerylang.org) — `filter`, `sort`, `pick`, `get`, `groupBy`,
   `uniq`

--- a/front/src/features/LSB/LSBRouterMenuItem/ui/LSBRouterMenuItem.vue
+++ b/front/src/features/LSB/LSBRouterMenuItem/ui/LSBRouterMenuItem.vue
@@ -44,6 +44,7 @@ const isSelectedMenu = (selectedMenuRoute: string): boolean => {
         ref="itemEl"
         class="l-s-b-router-menu-item"
         :class="{ selected: isSelectedMenu(it.id) }"
+        :data-testid="`lsb-${it.id}`"
         :to="{ name: it.id }"
         @mouseenter.native="state.hoveredItem = it.id"
         @mouseleave.native="state.hoveredItem = ''"

--- a/front/src/features/sourceServices/updateSourceService/ui/UpdateSourceService.vue
+++ b/front/src/features/sourceServices/updateSourceService/ui/UpdateSourceService.vue
@@ -206,6 +206,10 @@ const handleFileChange = async (event: Event) => {
   if (!file) return;
 
   clearPreview();
+  // Name the file straight away. Until now it only appeared once the preview had been built, so
+  // choosing a file and the rows arriving looked like one event - there was no moment on screen
+  // that said which file had been picked, or that one had been picked at all.
+  importedFileName.value = file.name;
   isParsing.value = true;
 
   try {
@@ -383,12 +387,24 @@ watch(
           How to prepare the file
         </a>
       </p>
+      <!--
+        The chosen file, on its own line. It stays put through reading, preview and problem, so the
+        sequence reads as three steps rather than as a list that appeared by itself.
+      -->
+      <p
+        v-if="importedFileName"
+        class="import-selected"
+        data-testid="source-import-filename"
+      >
+        Selected file: <strong>{{ importedFileName }}</strong>
+      </p>
+
       <div
         v-if="isParsing"
         class="import-status"
         data-testid="source-import-parsing"
       >
-        Reading the file…
+        Reading {{ importedFileName }}…
       </div>
 
       <div
@@ -396,7 +412,7 @@ watch(
         class="import-problem"
         data-testid="source-import-problem"
       >
-        <strong>{{ importedFileName }}</strong> — {{ importFileProblem }}
+        {{ importFileProblem }}
       </div>
 
       <div
@@ -409,7 +425,7 @@ watch(
             <strong data-testid="source-import-count">
               {{ previewRows.length }} connection(s)
             </strong>
-            from {{ importedFileName }}
+
             <span
               v-if="invalidRowCount > 0"
               class="preview-invalid"
@@ -535,6 +551,9 @@ watch(
         height: 1px;
         background-color: #e5e5e5;
       }
+    }
+    .import-selected {
+      @apply text-[0.8125rem] text-gray-700 mt-[0.5rem];
     }
     .import-status {
       @apply text-[0.8125rem] text-gray-600 py-[0.75rem];

--- a/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
+++ b/front/src/widgets/layout/helpPanel/ui/HelpPanel.vue
@@ -827,8 +827,8 @@ function jsonEditorGroup(): Group {
       {
         heading: 'Filter or reshape an array',
         steps: [
-          'Switch to the tree view, click the array so it is selected, then right-click it.',
-          'Sort and Transform act on what is selected. With nothing selected they act on the whole document, which is an object - that is why the wizard stays empty and the fields you expected never appear.',
+          'Switch to the tree view and click the array you want to work on - targetSpecList, nodeGroups, firewallRules - so the row is highlighted.',
+          'Right-click it, or press Ctrl+Q, and choose Sort or Transform. Both work on one array at a time, so pick the array first and the wizard will offer its fields.',
           'Transform replaces the array with the result, so check the document before saving.',
         ],
       },
@@ -968,6 +968,7 @@ onBeforeUnmount(() => {
       :class="docked ? 'is-docked' : 'is-float'"
       :style="panelStyle"
       data-testid="help-panel"
+      :data-docked="docked ? 'true' : 'false'"
     >
       <span
         class="help-resizer"
@@ -981,7 +982,9 @@ onBeforeUnmount(() => {
         data-testid="help-header"
         @mousedown="startMove"
       >
-        <span class="help-title">{{ help.title }}</span>
+        <span class="help-title" data-testid="help-title">{{
+          help.title
+        }}</span>
         <span class="help-actions">
           <button
             v-if="docked"
@@ -1027,7 +1030,7 @@ onBeforeUnmount(() => {
           </button>
         </span>
       </header>
-      <div class="help-body">
+      <div class="help-body" data-testid="help-body">
         <p v-for="(line, i) in help.paragraphs" :key="i">{{ line }}</p>
 
         <!-- What this menu does, as a list you can jump from. -->

--- a/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
+++ b/front/src/widgets/layout/menuCategory/ui/MenuCategory.vue
@@ -100,6 +100,7 @@ async function fetchMenuTree() {
         v-for="(n, i) in m.menu"
         :key="i"
         class="service-menu"
+        :data-testid="`menu-${n.id}`"
         :to="{ name: n.id }"
         :class="{
           'is-selected': selectedMenuId === n.id,

--- a/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
+++ b/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
@@ -125,7 +125,7 @@ const candidateLimit = ref<number>(3);
 /*
  * Minimum Match Rate — cm-beetle takes ONE number (query `minMatchRate`, 0-100, default 90.0).
  * There is no "max" counterpart, so this is a single field: a range string such as "90-100"
- * fails ParseFloat on the server, which then silently falls back to 90.0 (BAR-1634).
+ * fails ParseFloat on the server, which then silently falls back to 90.0.
  *
  * Empty means "send nothing" so the server default applies. The slider therefore rests at
  * MATCH_RATE_DEFAULT while the field is empty, and the hint under the field says which one is in effect.
@@ -549,7 +549,7 @@ function handleSave(e: { name: string; description: string }) {
             Provider sits in the same fixed-width cell as Candidate Limit on the row below, so
             "Region" and "Minimum Match Rate (%)" start at the same x. Aligning to whatever width
             the Provider dropdown happens to take does not work — its width follows the selected
-            value, so the column shifts between runs. (BAR-1634)
+            value, so the column shifts between runs.
           -->
           <section class="select-service-box params-section__row w-full">
             <div class="param-group">
@@ -626,7 +626,7 @@ function handleSave(e: { name: string; description: string }) {
                 Minimum Match Rate — one value only. cm-beetle exposes a single `minMatchRate`
                 (0-100, default 90) and answers anything it cannot parse by silently using 90,
                 so the screen must not invent a range. The '?' badge sits at the label's
-                bottom-right and opens the detailed explanation on hover/focus. (BAR-1634)
+                bottom-right and opens the detailed explanation on hover/focus.
               -->
               <span class="match-rate-label">
                 <span class="text-label-lg font-bold"
@@ -800,7 +800,7 @@ function handleSave(e: { name: string; description: string }) {
         data-testid cannot reach it otherwise. The replacement mirrors the default exactly —
         same style-type (tertiary), same label, and the `margin-top` the default carries via
         PIconModal's scoped `.button` rule (which does not reach parent-provided slot content)
-        is restored inline so the render is unchanged. (BAR-1595 / CLAUDE.md §12)
+        is restored inline so the render is unchanged.
       -->
       <template #custom-button>
         <p-button

--- a/front/src/widgets/models/targetModels/customViewTargetModel/ui/CustomViewTargetModel.vue
+++ b/front/src/widgets/models/targetModels/customViewTargetModel/ui/CustomViewTargetModel.vue
@@ -20,7 +20,11 @@ interface IProps {
 }
 
 const props = defineProps<IProps>();
-const emit = defineEmits(['update:close-modal', 'update:trigger', 'update:close-target-model-detail']);
+const emit = defineEmits([
+  'update:close-modal',
+  'update:trigger',
+  'update:close-target-model-detail',
+]);
 
 const modalState = reactive({
   open: false,
@@ -42,12 +46,12 @@ const modelData = computed(() => {
   if (props.migrationData) {
     return props.migrationData;
   }
-  
+
   // For a Software model, return targetSoftwareModel
   if (isSoftwareModel.value && targetModel.value?.targetSoftwareModel) {
     return targetModel.value.targetSoftwareModel;
   }
-  
+
   // For an Infra model, return cloudInfraModel
   return targetModel.value?.cloudInfraModel;
 });
@@ -58,17 +62,17 @@ const isSoftwareModel = computed(() => {
   if (props.migrationData) {
     return true;
   }
-  
+
   // Treat as a Software model when targetSoftwareModel is present
   if (targetModel.value?.targetSoftwareModel) {
     return true;
   }
-  
+
   // Treat as a Software model when migrationType is 'software'
   if (targetModel.value?.migrationType === 'software') {
     return true;
   }
-  
+
   // Default to an Infra model (preserves compatibility with existing logic)
   return false;
 });
@@ -81,17 +85,25 @@ watch(
         props.selectedTargetId,
       );
     }
-    
+
     // Stringify migration data with JSON.stringify if present, otherwise use the existing logic
     if (props.migrationData) {
       cloudInfraModelCode.value = JSON.stringify(props.migrationData, null, 2);
     } else {
       // For a Software model, display targetSoftwareModel
       if (isSoftwareModel.value && targetModel.value?.targetSoftwareModel) {
-        cloudInfraModelCode.value = JSON.stringify(targetModel.value.targetSoftwareModel, null, 2);
+        cloudInfraModelCode.value = JSON.stringify(
+          targetModel.value.targetSoftwareModel,
+          null,
+          2,
+        );
       } else {
         // For an Infra model, display cloudInfraModel
-        cloudInfraModelCode.value = JSON.stringify(targetModel.value?.cloudInfraModel || {}, null, 2);
+        cloudInfraModelCode.value = JSON.stringify(
+          targetModel.value?.cloudInfraModel || {},
+          null,
+          2,
+        );
       }
     }
   },
@@ -125,7 +137,10 @@ function handleCreateSoftwareTargetModel(e) {
       userModelVersion: targetModel.value?.userModelVersion ?? 'v0.1',
     };
   } catch (error) {
-    showErrorMessage('error', error instanceof Error ? error.message : 'Invalid JSON format');
+    showErrorMessage(
+      'error',
+      error instanceof Error ? error.message : 'Invalid JSON format',
+    );
     return;
   }
 
@@ -134,7 +149,10 @@ function handleCreateSoftwareTargetModel(e) {
       request: requestBody,
     })
     .then(res => {
-      showSuccessMessage('success', 'Successfully created software target model');
+      showSuccessMessage(
+        'success',
+        'Successfully created software target model',
+      );
       modalState.open = false;
       emit('update:close-modal', false);
       emit('update:trigger', false);
@@ -163,7 +181,10 @@ function handleCreateInfraTargetModel(e) {
       zone: targetModel.value?.zone ?? '',
     };
   } catch (error) {
-    showErrorMessage('error', error instanceof Error ? error.message : 'Invalid JSON format');
+    showErrorMessage(
+      'error',
+      error instanceof Error ? error.message : 'Invalid JSON format',
+    );
     return;
   }
 
@@ -194,7 +215,11 @@ function handleCodeUpdate(value: string) {
       class="page-modal-layout"
       :badge-title="selectedTargetName"
       :need-widget-layout="true"
-      :title="isSoftwareModel ? 'Save Software Migration as Target Model' : 'Custom & View Target Model'"
+      :title="
+        isSoftwareModel
+          ? 'Save Software Migration as Target Model'
+          : 'Custom & View Target Model'
+      "
       first-title="JSON Viewer"
       @update:modal-state="$emit('update:close-modal', false)"
     >
@@ -216,16 +241,26 @@ function handleCodeUpdate(value: string) {
       <template #buttons>
         <p-button
           style-type="tertiary"
+          data-testid="target-custom-cancel"
           @click="$emit('update:close-modal', false)"
         >
           Cancel
         </p-button>
-        <p-button @click="modalState.open = true"> Save</p-button>
+        <p-button
+          data-testid="target-custom-save"
+          @click="modalState.open = true"
+        >
+          Save</p-button
+        >
       </template>
     </create-form>
     <simple-edit-form
       v-if="modalState.open"
-      :header-title="isSoftwareModel ? 'Save software migration as target model' : 'Save new custom target model'"
+      :header-title="
+        isSoftwareModel
+          ? 'Save software migration as target model'
+          : 'Save new custom target model'
+      "
       :name="modalState.context.name"
       :description="modalState.context.description"
       name-label="Name"

--- a/front/src/widgets/models/targetModels/targetModelDetail/ui/TargetModelDetail.vue
+++ b/front/src/widgets/models/targetModels/targetModelDetail/ui/TargetModelDetail.vue
@@ -21,7 +21,9 @@ const { targetModelStore, setTargetModelId, initTable, tableModel } =
 
 // Computed that decides whether this is a Software model
 const isSoftwareModel = computed(() => {
-  const targetModel = targetModelStore.getTargetModelById(props.selectedTargetModelId);
+  const targetModel = targetModelStore.getTargetModelById(
+    props.selectedTargetModelId,
+  );
 
   // Treat as a Software model if modelType is 'SoftwareModel'
   if (targetModel?.modelType === 'SoftwareModel') {
@@ -88,30 +90,37 @@ watch(
 function handleJsonModal() {
   emit('update:custom-view-json-modal', true);
   emit('update:target-model-name', targetModelName.value);
-  
+
   // For a Software model, pass along the targetSoftwareModel info
   if (isSoftwareModel.value) {
-    const targetModel = targetModelStore.getTargetModelById(props.selectedTargetModelId);
+    const targetModel = targetModelStore.getTargetModelById(
+      props.selectedTargetModelId,
+    );
     if (targetModel?.targetSoftwareModel) {
       // Pass the targetSoftwareModel info to the parent component
       // This info is used by CustomViewTargetModel
-      console.log('Software model detected, targetSoftwareModel:', targetModel.targetSoftwareModel);
+      console.log(
+        'Software model detected, targetSoftwareModel:',
+        targetModel.targetSoftwareModel,
+      );
     }
   }
 }
 
 function handleOpenWorkflowEditor() {
-  const targetModel = targetModelStore.getTargetModelById(props.selectedTargetModelId);
-  
+  const targetModel = targetModelStore.getTargetModelById(
+    props.selectedTargetModelId,
+  );
+
   console.log('TargetModelDetail - handleOpenWorkflowEditor called:', {
     selectedTargetModelId: props.selectedTargetModelId,
     targetModelName: targetModelName.value,
     targetModelDescription: targetModelDescription.value,
     targetModel: targetModel,
     isSoftwareModel: isSoftwareModel.value,
-    targetSoftwareModel: targetModel?.targetSoftwareModel
+    targetSoftwareModel: targetModel?.targetSoftwareModel,
   });
-  
+
   emit('update:workflow-edit-modal', true);
 }
 </script>
@@ -125,7 +134,11 @@ function handleOpenWorkflowEditor() {
       :block="true"
     >
       <template #data-customAndViewJSON>
-        <p class="link-button-text" @click="handleJsonModal">
+        <p
+          class="link-button-text"
+          data-testid="target-detail-custom-view"
+          @click="handleJsonModal"
+        >
           Custom & View Target Model
         </p>
       </template>

--- a/front/src/widgets/workload/mci/mciList/ui/MciList.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciList.vue
@@ -278,6 +278,27 @@ onBeforeUnmount(() => {
               Create
             </p-button>
           </template>
+          <!--
+            The infrastructure's own id, marked so it can be addressed directly.
+
+            A migration names what it creates from the prefix it was given, so a test that goes
+            looking for a name is relying on a naming rule holding - and cannot tell this run's
+            infrastructure from one left behind by an earlier run. The id is the thing that is
+            actually unique, so it is carried on the cell as well as shown in it.
+
+            Both identifiers go on: the id is what the APIs are addressed by, and the uid is what
+            the platform assigns and what other records point at. Which one is to hand depends on
+            where you came from, so neither is left out.
+          -->
+          <template #col-id-format="{ item }">
+            <span
+              :data-testid="`mci-row-${item.id}`"
+              :data-infra-id="item.id"
+              :data-infra-uid="item.uid"
+            >
+              {{ item.id }}
+            </span>
+          </template>
           <template #col-provider-format="{ item, field }">
             <p-badge
               v-for="(provider, index) in item.provider"


### PR DESCRIPTION
## What this changes

Two things: the in-portal help for the JSON editor's array tools, and stable identifiers on screen elements.

## In-portal help

The help for **sort** and **transform** spent its words explaining why the tools look broken — that with nothing selected they act on the whole document, which is an object, so the wizard comes up empty. That is true, but it is not what a reader needs. What they need is how to use them.

Before:

> Sort and Transform act on what is selected. With nothing selected they act on the whole document, which is an object - that is why the wizard stays empty and the fields you expected never appear.

After:

> Switch to the tree view and click the array you want to work on - targetSpecList, nodeGroups, firewallRules - so the row is highlighted.
> Right-click it, or press Ctrl+Q, and choose Sort or Transform. Both work on one array at a time, so pick the array first and the wizard will offer its fields.

The help panel and `docs/guide/json-editor.md` now say the same thing, so it does not matter which one a reader opens.

## Stable identifiers

Screen elements were addressed by their wording, their position in the DOM, or the name of the resource they showed. All three break when the screen is edited, and the third is worse than it looks: a name tells you nothing about *which* resource you have, so a list holding two resources of the same name hands back whichever came first.

| Screen | Identifier |
|---|---|
| Sidebar (`MenuCategory.vue`) | `menu-{route name}` |
| Side list of a screen (`LSBRouterMenuItem.vue`) | `lsb-{route name}` |
| Workload list (`MciList.vue`) | `mci-row-{id}`, `data-infra-id`, `data-infra-uid` |
| Target model detail (`TargetModelDetail.vue`) | `target-detail-custom-view` |
| Target model editor (`CustomViewTargetModel.vue`) | `target-custom-save`, `target-custom-cancel` |
| Source service registration (`UpdateSourceService.vue`) | `source-import-filename` |
| Help panel (`HelpPanel.vue`) | `help-title`, `help-body`, `data-docked` |

The route name is used as the identifier, so a menu added later carries one without any further work, and renaming a label does not break it. The help panel's docked state is exposed as an attribute rather than read from a class, so restyling the panel does not change what it reports.

## Also on screen

The source service registration form now names the file that was chosen. It previously went straight from the file dialog to a preview, with nothing to say a file had been attached at all: `Selected file: …` → `Reading …` → preview.
