### PR TITLE
fix(front): correct two defects found while migrating to several providers

### DIFF
--- a/front/src/entities/mci/lib/deleteTracker.ts
+++ b/front/src/entities/mci/lib/deleteTracker.ts
@@ -7,9 +7,10 @@ import {
   type DeleteRequestRecord,
   type DeleteRequestStatus,
 } from '@/entities/mci/api/deleteRequest';
-import { useGetBeetleRequest, useGetMciList } from '@/entities/mci/api';
+import { useGetBeetleRequest } from '@/entities/mci/api';
 import { notify } from '@/entities/notification/lib/notificationStore';
 import { registerTracker } from '@/shared/libs/tracking/runner';
+import { toErrorMessage } from '@/shared/utils';
 
 /**
  * Tracking for workload (infra) deletes.
@@ -202,20 +203,27 @@ export async function loadDeleteRecords(): Promise<void> {
 // judged finished by querying cm-beetle, while a load test and a workflow each look at
 // something different. Folding those together would grow a switch, not a shared mechanism.
 
-/** Whether the infra is still listed — the tie-breaker when the outcome is unclear. */
-async function infraStillListed(rec: DeleteRecord): Promise<boolean> {
-  try {
-    const res: any = await useGetMciList(rec.nsId, '').execute();
-    const data =
-      res?.data?.responseData?.data ?? res?.data?.data ?? res?.data ?? {};
-    const list = data?.infra ?? data?.mci ?? [];
-    return (Array.isArray(list) ? list : []).some(
-      (m: any) => m?.uid === rec.uid,
-    );
-  } catch {
-    // If listing itself failed, decide nothing and look again on the next pass.
-    return true;
-  }
+/**
+ * The HTTP status behind a failed lookup, when there is one.
+ *
+ * The backend proxy passes cm-beetle's status through as-is when cm-beetle answered, and
+ * substitutes 500 when it could not reach cm-beetle at all. So the code tells the two apart:
+ * 404 means cm-beetle is up and does not know this request id, anything else means the
+ * outcome is still unknown.
+ */
+export function statusCodeOf(e: any): number | undefined {
+  // The api wrapper rejects with `{ error, errorMsg, status }`, all of them refs — the axios
+  // error sits at `error.value`, and `status` here is the wrapper's own 'error' | 'cancel'
+  // string, not an HTTP code. Reading that one first is what silently defeated this: it is
+  // never null, so it swallowed the lookup and every rejection came back without a code.
+  const fromWrapper = e?.error?.value?.response?.status;
+  if (typeof fromWrapper === 'number') return fromWrapper;
+
+  // A plain axios error, for callers that pass one through unwrapped.
+  const fromAxios = e?.response?.status;
+  if (typeof fromAxios === 'number') return fromAxios;
+
+  return typeof e?.status === 'number' ? e.status : undefined;
 }
 
 async function notifyDone(rec: DeleteRecord): Promise<void> {
@@ -256,12 +264,43 @@ async function notifyUnknown(rec: DeleteRecord): Promise<void> {
     level: 'Error',
     message: `Could not confirm the deletion of infra "${rec.infraId}".`,
     detail:
-      'The request record is gone but the infra is still listed, so the outcome is unknown. Check the workload list.',
+      'The request is no longer on record, so the outcome cannot be confirmed. Check the workload list to see whether it is gone.',
     dedupKey: `delete:${rec.reqId}:unknown`,
   });
 }
 
-/** Checks the outcome of one in-flight delete. */
+/**
+ * Says the status could not be read right now — the work itself is untouched.
+ *
+ * Holding off on a verdict is right, but staying silent about it is not: with nothing on
+ * screen the wait looks normal and nobody learns the server is unreachable. The key is per
+ * request rather than per attempt, so this is said once and not on every pass.
+ */
+async function notifyCheckUnavailable(
+  rec: DeleteRecord,
+  reason?: string,
+): Promise<void> {
+  await notify({
+    category: 'Workload',
+    level: 'Error',
+    message: `Cannot check the deletion status of infra "${rec.infraId}".`,
+    detail: reason
+      ? `${reason}\n\nThe delete itself is unaffected — checking resumes on its own once the server responds.`
+      : 'The server did not respond. The delete itself is unaffected — checking resumes on its own once the server responds.',
+    dedupKey: `delete:${rec.reqId}:check-unavailable`,
+  });
+}
+
+/**
+ * Checks the outcome of one in-flight delete.
+ *
+ * Everything here rests on cm-beetle's own request tracking, which has no rate limit. It
+ * used to fall back to listing the infras when that lookup failed — a listing that *is*
+ * rate limited (2/s), asked once per record, so deleting several at once put the later ones
+ * over the limit and their answers came back as failures. The fallback existed because a
+ * single `catch` treated "no such request" and "server unreachable" as the same thing; once
+ * those are told apart, there is nothing left for it to do.
+ */
 async function checkOne(rec: DeleteRecord): Promise<void> {
   try {
     const res: any = await useGetBeetleRequest(rec.reqId).execute();
@@ -284,20 +323,25 @@ async function checkOne(rec: DeleteRecord): Promise<void> {
       await notifyFailed(rec, reason);
     }
     // Still Handling: leave it and look again on the next pass.
-  } catch {
-    // The lookup failed. cm-beetle's request records do not survive its restart, so a
-    // request that completed normally can land here. Rather than calling it failed, decide
-    // by whether the infra is still there.
-    const listed = await infraStillListed(rec);
-    if (!listed) {
-      // No infra means it is gone by some route. Nothing to keep.
-      await notifyDone(rec);
-      await clearDeleteRecord(rec.uid);
-    } else {
-      // The infra is there but the request record is not — the outcome is unknown.
+  } catch (e) {
+    if (statusCodeOf(e) === 404) {
+      // cm-beetle answered and does not know this request id. Its records are kept for a
+      // week and restored on restart, so this is either an old request or one lost to a
+      // crash — and in the last case the request may never have reached cm-beetle at all.
+      // Either way the outcome can no longer be learned from here.
+      //
+      // Leaving it in `Handling` would be worse than saying so: that status is what blocks
+      // a second delete, so the workload could never be deleted again. Move it out and say
+      // the outcome is unknown.
       await markStatus(rec.uid, 'Unknown');
       await notifyUnknown(rec);
+      return;
     }
+
+    // Anything else — 500, a network failure — means the answer did not arrive, not that
+    // the delete failed. Do not pretend to have one. Say the check is unavailable and look
+    // again next pass.
+    await notifyCheckUnavailable(rec, toErrorMessage(e, ''));
   }
 }
 

--- a/front/src/widgets/models/recommendedInfraModel/model/useRecommendedInfraModel.ts
+++ b/front/src/widgets/models/recommendedInfraModel/model/useRecommendedInfraModel.ts
@@ -216,44 +216,36 @@ export function useRecommendedInfraModel() {
       }
     });
 
-    // Extract OS and Architecture from targetOsImageList
+    // OS and Architecture come from the image entry's own normalized fields.
+    //
+    // The image list carries two layers. `osType`/`osArchitecture` are normalized by
+    // cb-tumblebug so every provider reports them the same way, while `description` and
+    // `details[]` are whatever the provider itself returned — their shape differs per
+    // provider and is not something to parse. This used to read the provider-supplied
+    // layer, so it only worked where that layer happened to look like AWS: `description`
+    // is empty on NCP, and the architecture key is named `CpuArchitectureType` there
+    // rather than `Architecture`. Both columns then showed "n/a" even though the
+    // normalized fields held the right values all along.
+    //
+    // `imageId` on a nodeGroup refers to the image entry's `id`, so match on that.
+    // Nothing is guessed when a value is absent — the column stays empty and the table
+    // renders "n/a", which is the honest answer.
     const osValues: string[] = [];
     const archValues: string[] = [];
-    
+
     recommendedModel.targetInfra.nodeGroups?.forEach(subGroup => {
-      // Find matching image
       const matchingImage = recommendedModel.targetOsImageList?.find(
-        image => image.cspImageName === subGroup.imageId
+        image => image.id === subGroup.imageId,
       );
-      
+
       if (matchingImage) {
-        // Extract OS from description (e.g., "Canonical, Ubuntu, 22.04, amd64 jammy image")
-        if (matchingImage.description) {
-          // Try to parse OS name from description
-          const desc = matchingImage.description;
-          // Common patterns: "Ubuntu 22.04", "Canonical, Ubuntu, 22.04", etc.
-          const osMatch = desc.match(/Ubuntu\s+[\d.]+|Windows\s+Server\s+[\d]+|CentOS\s+[\d.]+|RHEL\s+[\d.]+|Amazon\s+Linux\s+[\d]+/i);
-          if (osMatch) {
-            osValues.push(osMatch[0]);
-          } else {
-            // Fallback: use first part of description
-            const parts = desc.split(',').map(p => p.trim());
-            if (parts.length >= 2) {
-              osValues.push(`${parts[1]} ${parts[2] || ''}`.trim());
-            } else {
-              osValues.push(parts[0] || 'Unknown');
-            }
-          }
+        if (matchingImage.osType) {
+          osValues.push(matchingImage.osType);
         }
-        
-        // Extract Architecture from details
-        if (matchingImage.details && Array.isArray(matchingImage.details)) {
-          const archDetail = matchingImage.details.find(
-            (detail: any) => detail.key === 'Architecture'
-          );
-          if (archDetail && archDetail.value) {
-            archValues.push(archDetail.value);
-          }
+        // 'NA' is the image list's way of saying the architecture is unknown, so it is
+        // not shown as if it were an answer.
+        if (matchingImage.osArchitecture && matchingImage.osArchitecture !== 'NA') {
+          archValues.push(matchingImage.osArchitecture);
         }
       }
     });

--- a/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
+++ b/front/src/widgets/models/recommendedInfraModel/ui/RecommendedInfraModel.vue
@@ -759,7 +759,24 @@ function handleSave(e: { name: string; description: string }) {
               <span v-html="formatEmptyValue(item.spec)" />
             </template>
             <template #col-image-format="{ item }">
-              <span v-html="formatEmptyValue(item.image)" />
+              <span data-testid="recommend-image" v-html="formatEmptyValue(item.image)" />
+            </template>
+            <!--
+              OS and Architecture carry an identifier so a test can read the cell itself.
+              Reading them by column position breaks the moment a column moves, and these
+              two are exactly what regressed before: they showed "n/a" on every provider
+              except AWS because the values were taken from provider-supplied fields
+              instead of the normalized ones.
+
+              The slot always renders a span, even when the value is empty — a slot that
+              renders nothing makes the table fall back to its own default rendering
+              (DESIGN-MIRINAE §1.7).
+            -->
+            <template #col-os-format="{ item }">
+              <span data-testid="recommend-os">{{ item.os }}</span>
+            </template>
+            <template #col-architecture-format="{ item }">
+              <span data-testid="recommend-architecture">{{ item.architecture }}</span>
             </template>
           </p-toolbox-table>
         </div>

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -12,9 +12,11 @@ import { useDeleteMci } from '@/entities/mci/api';
 import {
   putDeleteRecord,
   markDeleteSucceeded,
+  markDeleteFailed,
   noteDeleteRequestError,
   getDeleteRecord,
   isDeleteInProgress,
+  statusCodeOf,
   type DeleteRecord,
 } from '@/entities/mci/lib/deleteTracker';
 import { extractErrorMessage } from '@/shared/libs';
@@ -142,19 +144,26 @@ function fireDeletes(mciList: any[], option: string): string[] {
       // Announce the success from here. The tracker cannot: clearing on success would take
       // the record out of what it inspects, so nothing would ever report the completion.
       .then(() => markDeleteSucceeded(uid))
-      // **A failed request is not a failed delete.** This call runs for minutes and the proxy
-      // gives up at 504 long before the server does; the delete carries on and usually
-      // succeeds. Marking Error here told the user it had failed while the infra was in fact
-      // being removed — observed on the dev server, where the infra was gone and the screen
-      // said it had failed.
-      //
-      // So leave the record in Handling and let the tracker decide: it asks cm-beetle for the
-      // request, and when that cannot answer it falls back to whether the infra is still
-      // listed. Only that can tell a delete that failed from one that is merely slow. The
-      // reason is kept on the record so it can be shown if the tracker does conclude failure.
-      .catch((rejected: any) =>
-        noteDeleteRequestError(uid, reasonFrom(rejected) ?? undefined),
-      );
+      .catch((rejected: any) => {
+        const reason = reasonFrom(rejected) ?? undefined;
+        const code = statusCodeOf(rejected);
+
+        // **A timeout is not a failed delete.** This call runs for minutes and the proxy
+        // gives up at 504 long before the server does; the delete carries on and usually
+        // succeeds. Marking Error here told the user it had failed while the infra was in
+        // fact being removed — observed on the dev server, where the infra was gone and the
+        // screen said it had failed. Leave it in Handling and let the tracker conclude.
+        if (code === undefined || code === 504 || code >= 500) {
+          noteDeleteRequestError(uid, reason);
+          return;
+        }
+
+        // Anything else the server rejected outright (400, 401, 403, …) means the delete
+        // never started. Leaving it in Handling would be the worst outcome: that status is
+        // what blocks a second attempt, so the workload could never be deleted again even
+        // though nothing had happened to it. Close it out as a failure, with the reason.
+        markDeleteFailed(uid, reason);
+      });
     uids.push(uid);
   }
   return uids;


### PR DESCRIPTION
Two defects surfaced while running migrations against several providers.

## 1. Recommendation results showed no OS or architecture outside AWS

The two columns were parsed out of fields the provider itself returned — a description text and a details list — and those differ per provider:

| | AWS | another provider |
|---|---|---|
| `description` | `Canonical, Ubuntu, 22.04, amd64 jammy image` | **empty** |
| architecture key in `details[]` | `Architecture` | **`CpuArchitectureType`** |
| result on screen | shown | **`n/a`** |

The values were present the whole time. The image list carries normalized fields for exactly this purpose — `osType` and `osArchitecture`, resolved on the way in so every provider reports them the same way:

```
osType         = 'Ubuntu 22.04'
osArchitecture = 'x86_64'
```

Read those instead, and match the image by its `id`, which is what a node group's `imageId` refers to.

**No fallback to the old parsing.** Leaving it behind would let provider text slip in whenever a normalized field is empty, and a wrong value reads as a working one. An absent value stays absent and the table shows `n/a`.

Verified by calling the recommendation API with the same on-premise input and only the target provider changed:

| provider | before | after |
|---|---|---|
| the one that was blank | `n/a` / `n/a` | `Ubuntu 22.04` / `x86_64` |
| AWS | shown | shown (no regression) |

## 2. Deleting several workloads at once left some of them showing as failed

The delete request was never the problem — that path has no rate limit. The status check was:

```ts
} catch {
  const listed = await infraStillListed(rec);   // lists infras, once per record
```

That listing allows two calls a second, so from the third record on it was turned away, and the refusal read as a failed delete.

The fallback only existed because a single `catch` treated two different situations as one. Branching on the status tells them apart and removes the need to ask anything else:

| response | meaning | handling |
|---|---|---|
| 200 + status | in progress / finished | as reported |
| **404** | the server answered and does not know that request id | **end the tracking** |
| **500 · network** | no answer arrived | **no verdict**, but report that the check is unavailable |

**Why a 404 has to end it** — that in-progress status is not just a label, it is what blocks a second delete. A record left there would make the workload permanently undeletable.

**Why no grace period is needed** — the request id is recorded by middleware that runs before the handler, so if a response came back the record already exists.

A request refused outright is closed as failed for the same reason: a timeout means the server is still working, while a refusal means nothing started, and only one of those should stay in progress.

Compared against the base branch under identical conditions — the same scenarios pass, with no newly broken ones.