### PR TITLE
improve(workload): let a mixed selection through the delete confirmation

### DIFF
--- a/front/src/shared/ui/Button/dynamicIconButton/DynamicTableIconButton.vue
+++ b/front/src/shared/ui/Button/dynamicIconButton/DynamicTableIconButton.vue
@@ -2,13 +2,16 @@
 import { PIconButton } from '@cloudforet-test/mirinae';
 interface IProps {
   name: string;
+  // The button is mounted into the table's toolbar at runtime, so a testid cannot be written
+  // into any template. It is passed here instead and lands on the wrapper.
+  testid?: string;
 }
 
 const props = defineProps<IProps>();
 </script>
 
 <template>
-  <div class="tool">
+  <div class="tool" :data-testid="props.testid">
     <p-icon-button :name="props.name" @click="$emit('click')"> </p-icon-button>
   </div>
 </template>

--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -7,7 +7,7 @@ import {
   PRadioGroup,
   PTextInput,
 } from '@cloudforet-test/mirinae';
-import { computed, reactive, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue';
 import { useDeleteMci } from '@/entities/mci/api';
 import {
   putDeleteRecord,
@@ -35,9 +35,10 @@ interface IEmits {
 const props = defineProps<IProps>();
 const emit = defineEmits<IEmits>();
 
-// The modal has two steps.
-//   confirm  — choose the method (Normal/Force) and type the name to confirm
-//   progress — shows how the delete is going, from request until it finishes.
+// The modal has three steps.
+//   confirm  — choose the method (Normal/Force) and type the phrase to confirm
+//   progress — shows how the delete is going, from request until it finishes
+//   error    — reopened after an earlier delete failed: the reason, and what to do about it
 // The delete is *asynchronous*: the request is tracked by reqId (deleteTracker), so
 // closing this modal and coming back later still shows the same state in the list.
 const state = reactive({
@@ -48,14 +49,90 @@ const state = reactive({
   // error    — reopened after an earlier delete failed: reason, plus force delete or cancel
   phase: 'confirm' as 'confirm' | 'progress' | 'error',
   alreadyInProgress: false,
+  // Set for a few seconds after the requests go out; see lockClose below.
+  closeLocked: false,
 });
 
 const trackedIds = ref<string[]>([]);
 
+/**
+ * What is about to happen to each selected workload.
+ *
+ *   new      — nothing has been requested for it yet
+ *   retry    — an earlier delete failed; this run asks again
+ *   inflight — a delete is already running, so no second request is sent for it
+ */
+type TargetKind = 'new' | 'retry' | 'inflight';
+
+interface DeleteTarget {
+  uid: string;
+  name: string;
+  kind: TargetKind;
+}
+
+/**
+ * The targets, worked out once when the modal opens rather than on every render.
+ *
+ * A record can change under the modal — the tracker polls in the background — and the
+ * confirm keyword is derived from this list. Recomputing would move the keyword while it is
+ * being typed, so what the user is answering about is fixed at the moment they are asked.
+ */
+const targets = ref<DeleteTarget[]>([]);
+
+function classifyTargets(mciList: any[]): DeleteTarget[] {
+  return mciList
+    .map(mci => ({ uid: mci?.uid as string, name: (mci?.name as string) ?? '' }))
+    // Without a uid there is nothing to track — a name is reused and cannot be the key.
+    .filter(t => !!t.uid)
+    .map(t => {
+      const status = getDeleteRecord(t.uid)?.status;
+      const kind: TargetKind =
+        status === 'Handling' ? 'inflight' : status === 'Error' ? 'retry' : 'new';
+      return { ...t, kind };
+    });
+}
+
+// The ones a confirm actually sends a request for — everything except those already running.
+const requestTargets = computed(() =>
+  targets.value.filter(t => t.kind !== 'inflight'),
+);
+const inflightTargets = computed(() =>
+  targets.value.filter(t => t.kind === 'inflight'),
+);
+const retryTargets = computed(() => targets.value.filter(t => t.kind === 'retry'));
+
+/**
+ * What has to be typed to confirm.
+ *
+ * It follows how much is being deleted, because that is the thing the user has to be sure
+ * of. One target asks for its name; a few ask for all of their names; beyond that the names
+ * are too long to type, so the phrase carries the count instead.
+ *
+ * The count is of what is *about to be requested*, not of what is selected — a workload
+ * already being deleted is not part of this delete.
+ */
 const checkKeyword = computed(() => {
-  return props.selectedMciList.length === 1
-    ? props.selectedMciList[0].name
-    : 'Delete All';
+  const names = requestTargets.value.map(t => t.name).filter(Boolean);
+  if (names.length === 0) return 'Delete';
+  if (names.length === 1) return names[0];
+  if (names.length <= 3) return names.join(', ');
+  return `Delete ${names.length} Workloads`;
+});
+
+// Said before the request goes out: some of what was selected is not part of it.
+const exclusionNotice = computed(() => {
+  const excluded = inflightTargets.value.length;
+  if (!excluded) return '';
+  const verb = excluded === 1 ? 'is' : 'are';
+  return `${excluded} of the ${targets.value.length} selected workloads ${verb} already being deleted and ${verb} not part of this request.`;
+});
+
+const retryNotice = computed(() => {
+  const retries = retryTargets.value.length;
+  if (!retries) return '';
+  const subject = retries === 1 ? 'One workload' : `${retries} workloads`;
+  const verb = retries === 1 ? 'has' : 'have';
+  return `${subject} ${verb} failed a delete before and will be requested again.`;
 });
 
 // In confirm the name must match exactly; in progress the confirm button is blocked so the
@@ -169,12 +246,47 @@ function fireDeletes(mciList: any[], option: string): string[] {
   return uids;
 }
 
+/**
+ * Holds the dialog open for a moment after the requests go out.
+ *
+ * The delete is a synchronous call that runs for minutes, so there is no reply to say the
+ * request was accepted. What there is: cm-beetle writes the request down the instant it
+ * arrives, before the handler runs. Once that has had time to happen the outcome can be
+ * fetched by reqId from anywhere, so leaving is safe — but leaving *before* it means the
+ * request may never have landed and nothing is left to look it up with.
+ */
+const CLOSE_LOCK_MS = 5000;
+let closeLockTimer: ReturnType<typeof setTimeout> | undefined;
+
+function lockClose() {
+  state.closeLocked = true;
+  if (closeLockTimer) clearTimeout(closeLockTimer);
+  closeLockTimer = setTimeout(() => {
+    state.closeLocked = false;
+    closeLockTimer = undefined;
+  }, CLOSE_LOCK_MS);
+}
+
+function unlockClose() {
+  if (closeLockTimer) {
+    clearTimeout(closeLockTimer);
+    closeLockTimer = undefined;
+  }
+  state.closeLocked = false;
+}
+
+onBeforeUnmount(unlockClose);
+
 // Runs the delete from confirm: issue the request and move to progress rather than closing.
+// Everything selected is passed on — fireDeletes skips the ones already running, so they are
+// tracked and shown without a second request going out for them.
 function handleConfirm() {
   if (state.phase !== 'confirm') return;
   const option = state.deleteMethod === 'force' ? 'force' : 'terminate';
-  trackedIds.value = fireDeletes(props.selectedMciList, option);
+  state.alreadyInProgress = inflightTargets.value.length > 0;
+  trackedIds.value = fireDeletes(targets.value, option);
   state.phase = 'progress';
+  lockClose();
   emit('deleted'); // refresh so the list brings up the Delete Status column at once
 }
 
@@ -182,12 +294,13 @@ function handleConfirm() {
 // Force leaves the CSP resources and removes only the internal records, as the banner says.
 // The records are in Error rather than in flight, so fireDeletes issues fresh reqIds.
 function handleForceDelete() {
-  const targets = erroredRecords.value.map(r => ({
+  const forceTargets = erroredRecords.value.map(r => ({
     uid: r.uid,
     name: r.infraId,
   }));
-  trackedIds.value = fireDeletes(targets, 'force');
+  trackedIds.value = fireDeletes(forceTargets, 'force');
   state.phase = 'progress';
+  lockClose();
   emit('deleted');
 }
 
@@ -197,6 +310,7 @@ function handleForceDelete() {
 function handleRetry() {
   state.deleteMethod = 'normal';
   state.confirmKeyword = '';
+  targets.value = classifyTargets(props.selectedMciList);
   state.phase = 'confirm';
 }
 
@@ -219,20 +333,38 @@ function resetState() {
   state.confirmKeyword = '';
   state.phase = 'confirm';
   state.alreadyInProgress = false;
+  unlockClose();
   trackedIds.value = [];
+  targets.value = [];
 }
 
 // Close — the delete carries on and the list keeps showing its state.
 // The list is what is behind this modal, so refresh on close to bring up Delete Status.
 function handleClose() {
+  if (state.closeLocked) return;
   emit('deleted');
   closeAndReset();
 }
 
-// The step is chosen from the targets' current delete records when the modal opens.
-//   Handling → progress (says one is already running, and shows its state)
-//   Error    → error (the earlier failure, its reason, and force delete or cancel)
-//   none     → confirm (choose the method and type the name)
+// The dialog's own close paths (the X, the backdrop) go through here so the hold after a
+// request applies to them as well; refusing to emit leaves `visible` as it was.
+function handleVisibleUpdate(value: boolean) {
+  if (!value && state.closeLocked) return;
+  emit('update:visible', value);
+}
+
+/**
+ * Picks the step from what the selected workloads are currently up to.
+ *
+ *   anything not yet requested → confirm (choose the method and type the name)
+ *   otherwise, some failed     → error (the reasons, and force delete or retry)
+ *   otherwise                  → progress (they are all already running)
+ *
+ * The first line is the important one. Opening on progress whenever *one* of the selection
+ * was already running left the rest unrequested — that step has no delete button, so there
+ * was no way to ask for them and nothing on screen said they had been left out. Reaching
+ * confirm is what gets them sent; the request loop already skips the ones in flight.
+ */
 watch(
   () => props.visible,
   visible => {
@@ -240,23 +372,21 @@ watch(
       resetState();
       return;
     }
-    const uids = props.selectedMciList
-      .map(m => m.uid as string)
-      .filter(Boolean);
-    const inProgress = uids.filter(uid => isDeleteInProgress(uid));
-    const errored = uids.filter(
-      uid => getDeleteRecord(uid)?.status === 'Error',
-    );
-    if (inProgress.length > 0) {
-      trackedIds.value = inProgress;
-      state.phase = 'progress';
-      state.alreadyInProgress = true;
-    } else if (errored.length > 0) {
-      trackedIds.value = errored;
-      state.phase = 'error';
-    } else {
+    targets.value = classifyTargets(props.selectedMciList);
+    const pending = targets.value.filter(t => t.kind === 'new');
+    const errored = targets.value.filter(t => t.kind === 'retry');
+    const inProgress = targets.value.filter(t => t.kind === 'inflight');
+
+    if (pending.length > 0 || targets.value.length === 0) {
       state.phase = 'confirm';
       state.alreadyInProgress = false;
+    } else if (errored.length > 0) {
+      trackedIds.value = errored.map(t => t.uid);
+      state.phase = 'error';
+    } else {
+      trackedIds.value = inProgress.map(t => t.uid);
+      state.phase = 'progress';
+      state.alreadyInProgress = true;
     }
   },
 );
@@ -270,7 +400,7 @@ watch(
     size="sm"
     hide-footer
     @close="handleClose"
-    @update:visible="$emit('update:visible', $event)"
+    @update:visible="handleVisibleUpdate"
   >
     <template #body>
       <!-- error step — reopened after a failure: the reason (scrolls if long), force delete or cancel -->
@@ -308,9 +438,13 @@ watch(
         class="delete-modal-content"
         data-testid="mci-delete-progress"
       >
-        <div v-if="state.alreadyInProgress" class="warning-banner">
-          A delete is already in progress. Showing its current state instead of
-          starting a new one.
+        <div
+          v-if="state.alreadyInProgress"
+          class="warning-banner"
+          data-testid="mci-delete-already-running"
+        >
+          Some of these were already being deleted. Their current state is shown
+          and no second request was sent for them.
         </div>
         <p class="description">Deleting</p>
         <div class="mci-list">
@@ -339,14 +473,22 @@ watch(
             <span v-else class="progress-status done">Deleted</span>
           </div>
         </div>
-        <p v-if="anyHandling" class="hint">
+        <p
+          v-if="state.closeLocked"
+          class="hint"
+          data-testid="mci-delete-accepting"
+        >
+          Handing the request over. This takes a moment — once it is done you can
+          leave and the result will still find its way back.
+        </p>
+        <p v-else-if="anyHandling" class="hint">
           Closing this dialog does not stop the delete. You can follow it in the
           <b>Delete Status</b> column of the list.
         </p>
       </div>
 
       <!-- confirm step — choose the method and type the name -->
-      <div v-else class="delete-modal-content">
+      <div v-else class="delete-modal-content" data-testid="mci-delete-confirm">
         <div class="warning-banner">
           ⚠️ Deleting workloads will also delete
           <span class="keyword-highlight"
@@ -357,12 +499,38 @@ watch(
             >from a few minutes to several hours</span
           >
         </div>
-        <p class="description">The following workloads will be deleted</p>
+        <p class="description" data-testid="mci-delete-target-count">
+          {{ requestTargets.length === 1 ? '1 workload' : `${requestTargets.length} workloads` }}
+          will be deleted
+        </p>
         <div class="mci-list">
-          <div v-for="mci in selectedMciList" :key="mci.name" class="mci-item">
-            {{ mci.name }}
+          <div
+            v-for="target in targets"
+            :key="target.uid"
+            class="mci-item"
+            :class="{ excluded: target.kind === 'inflight' }"
+            :data-testid="`mci-delete-target-${target.kind}`"
+          >
+            <span class="target-name">{{ target.name }}</span>
+            <span v-if="target.kind === 'inflight'" class="target-note"
+              >already deleting — not included</span
+            >
+            <span v-else-if="target.kind === 'retry'" class="target-note"
+              >failed before — will be requested again</span
+            >
+            <span v-else />
           </div>
         </div>
+        <p
+          v-if="exclusionNotice"
+          class="warning-note"
+          data-testid="mci-delete-excluded-notice"
+        >
+          {{ exclusionNotice }}
+        </p>
+        <p v-if="retryNotice" class="hint" data-testid="mci-delete-retry-notice">
+          {{ retryNotice }}
+        </p>
 
         <p-field-group label="Delete Method" required class="mt-8">
           <div
@@ -443,6 +611,7 @@ watch(
           <p-button
             style-type="transparent"
             data-testid="wl-delete-close"
+            :disabled="state.closeLocked"
             @click="handleClose"
           >
             Close
@@ -497,9 +666,25 @@ watch(
     overflow-y: auto;
 
     .mci-item {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
       padding: 4px 0;
       font-size: 14px;
+    }
+    .mci-item .target-name {
       font-family: monospace;
+    }
+    /* Struck through so a row left out of this request reads as left out at a glance. */
+    .mci-item.excluded .target-name {
+      color: #9ca3af;
+      text-decoration: line-through;
+    }
+    .mci-item .target-note {
+      font-size: 0.75rem;
+      color: #6b7280;
+      white-space: nowrap;
     }
 
     .progress-item {
@@ -543,6 +728,13 @@ watch(
     margin-top: 10px;
     font-size: 12px;
     color: #6b7280;
+    line-height: 1.5;
+  }
+
+  .warning-note {
+    margin-top: 10px;
+    font-size: 12px;
+    color: #92400e;
     line-height: 1.5;
   }
 

--- a/front/src/widgets/workload/mci/mciList/ui/MciList.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciList.vue
@@ -15,6 +15,7 @@ import {
   computed,
   ref,
   watch,
+  nextTick,
 } from 'vue';
 import MciDeleteModal from './MciDeleteModal.vue';
 import LifecycleControlModal from '@/features/workload/lifecycleControl/ui/LifecycleControlModal.vue';
@@ -25,6 +26,8 @@ import {
 } from '@/features/workload/lifecycleControl/model';
 import type { LifecycleAction } from '@/entities/mci/api';
 import TableLoadingSpinner from '@/shared/ui/LoadingSpinner/TableLoadingSpinner.vue';
+import DynamicTableIconButton from '@/shared/ui/Button/dynamicIconButton/DynamicTableIconButton.vue';
+import { insertDynamicComponent } from '@/shared/utils';
 import { useDynamicTableHeight } from '@/shared/hooks/table/useDynamicTableHeight';
 import { useToolboxTableHeight } from '@/shared/hooks/table/useToolboxTableHeight';
 import {
@@ -69,18 +72,16 @@ const isActionDisabled = computed(() => {
   return mciTableModel.tableState.selectIndex.length === 0;
 });
 
-// Lifecycle first, then a rule, then Delete. Delete is the one that cannot be undone and the one
-// that was here before, so it keeps its place at the bottom rather than sitting among the others.
+// Lifecycle actions only. Delete sits in the toolbar as an icon next to refresh, where every
+// other list in the console keeps it.
 const actionState = reactive({
-  actionMenus: computed(() => [
-    ...LIFECYCLE_ACTION_ORDER.map(action => ({
+  actionMenus: computed(() =>
+    LIFECYCLE_ACTION_ORDER.map(action => ({
       name: action,
       label: LIFECYCLE_ACTIONS[action].label,
       disabled: isActionDisabled.value,
     })),
-    { type: 'divider' },
-    { name: 'delete', label: 'Delete', disabled: isActionDisabled.value },
-  ]),
+  ),
   selectedActionItem: '',
 });
 
@@ -114,14 +115,43 @@ const lifecycleTargets = computed<ILifecycleTarget[]>(() =>
 );
 
 function handleAction(item: string) {
-  if (item === 'delete') {
-    deleteModalState.visible = true;
-    return;
-  }
   if (LIFECYCLE_ACTION_ORDER.includes(item as LifecycleAction)) {
     lifecycleModalState.action = item as LifecycleAction;
     lifecycleModalState.visible = true;
   }
+}
+
+/**
+ * Puts the delete button in the table's toolbar, beside refresh.
+ *
+ * Every other list in the console carries delete there, so this one did not belong in the
+ * action dropdown. The toolbar is drawn by the table component and has no slot for that spot,
+ * so the button is mounted into it — the same way the other lists do it.
+ *
+ * The table is re-rendered on every load (`tableKey`), which throws the mounted node away, so
+ * this runs after each load and checks whether the node is still there.
+ */
+function mountDeleteButton() {
+  const table = toolboxTableRef.value?.$el as HTMLElement | undefined;
+  const toolGroup = table?.querySelector('.right-tool-group');
+  if (!toolGroup || toolGroup.querySelector('[data-testid="mci-delete-action"]')) return;
+
+  insertDynamicComponent(
+    DynamicTableIconButton,
+    { name: 'ic_delete', testid: 'mci-delete-action' },
+    {
+      // Same behaviour the dropdown item had: open the dialog for whatever is selected.
+      // Deciding what can actually be deleted is the dialog's job — a workload already being
+      // deleted is left out there rather than being kept out of the dialog.
+      click: () => {
+        if (mciTableModel.tableState.selectIndex.length > 0) {
+          deleteModalState.visible = true;
+        }
+      },
+    },
+    toolGroup as HTMLElement,
+    'prepend',
+  );
 }
 
 async function handleDeleted() {
@@ -204,6 +234,17 @@ onMounted(async () => {
   // re-render after the initial data load
   tableKey.value++;
 });
+
+// The table is thrown away and drawn again on every load, taking the mounted delete button with
+// it, so it is put back once the table is on screen again.
+watch(
+  [loading, tableKey],
+  () => {
+    if (loading.value) return;
+    nextTick(mountDeleteButton);
+  },
+  { immediate: true },
+);
 
 // Leaving the screen ends the transition watch. It only exists to keep *this* list honest.
 onBeforeUnmount(() => {


### PR DESCRIPTION
## What

Deleting several workloads at once used to stop short when any one of the selection was already being deleted.

That guard was deliberate. Issuing a second delete for the same workload leaves it unclear what the later one removes, and since there is no separate place to watch a delete run, the dialog showed that one's progress instead of starting anything new.

What it also did was leave **the rest of the selection** alone — nothing was requested for them, and nothing on screen said so, because only the workload already running was listed.

The confirmation now opens whenever something in the selection has not been requested yet. The ones already running are shown as left out of this request rather than dropped quietly, and **no second request goes out for them**.

## Before / after

Two workloads picked, one of them (`mock-del-infra`) already being deleted.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/dialog-before.png" width="420"> | <img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/dialog-after.png" width="420"> |
| Only the one already running is listed, and the sole button is `Close` — there is no way to ask for the other. | The one already running is struck through as *already deleting — not included*, with a line saying how many of the selection are left out. The phrase to type is the workload that will actually be deleted. |

## Also on the same screen

**The phrase to type now says how much is going.** It was the name for one target and `Delete All` for anything above that, so two and twenty read the same and neither told you the scope — and "All" is not true when only part of the list is selected.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/phrase-before.png" width="420"> | <img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/phrase-after.png" width="420"> |

| Selected | Before | After |
|---|---|---|
| 1 | the name | the name |
| 2 | `Delete All` | `mock-list-infra-2, mock-list-infra-3` |
| 4 | `Delete All` | `Delete 4 Workloads` |

The count is of what is *about to be requested*, not of what is selected — a workload already being deleted is not part of this delete.

**The dialog is held briefly after the request goes out.** Deleting answers only when it finishes, so there is no acknowledgement to wait for. What there is, is that the request is written down as soon as it arrives. Close is held for a few seconds so that has time to happen, and says why.

<img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/close-hold.png" width="420">

**Delete moves to the toolbar.** It was an item in the action dropdown; every other list in the console keeps delete as an icon beside refresh. The dropdown now carries the lifecycle actions alone. The button does what the dropdown item did — opens the confirmation for whatever is selected.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/placement-before.png" width="420"> | <img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/placement-after.png" width="420"> |

## How it was checked

The previous build and this one were built as images and run side by side against the same backend, and the same end-to-end scenarios were run against both. Every scenario that passed before still passes, and a new scenario covering the mixed selection fails on the previous build — which is what makes it worth having. The scenarios that go through delete press the moved icon.

Type check, scenario generation and the image build all pass.
