### PR TITLE
improve(workload): send delete requests one at a time and show the two waits apart

### DIFF
--- a/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
+++ b/front/src/widgets/workload/mci/mciList/ui/MciDeleteModal.vue
@@ -20,6 +20,7 @@ import {
   type DeleteRecord,
 } from '@/entities/mci/lib/deleteTracker';
 import { extractErrorMessage } from '@/shared/libs';
+import { McmpRouter } from '@/app/providers/router';
 
 interface IProps {
   visible: boolean;
@@ -45,11 +46,15 @@ const state = reactive({
   deleteMethod: 'normal',
   confirmKeyword: '',
   // confirm  — choose the method and type the name
+  // notice   — a large selection: what the wait is for, before anything is sent
+  // dispatch — handing the requests over, one at a time; the screen is held here
   // progress — deleting, shown until it finishes
   // error    — reopened after an earlier delete failed: reason, plus force delete or cancel
-  phase: 'confirm' as 'confirm' | 'progress' | 'error',
+  phase: 'confirm' as 'confirm' | 'notice' | 'dispatch' | 'progress' | 'error',
   alreadyInProgress: false,
-  // Set for a few seconds after the requests go out; see lockClose below.
+  // How many requests have gone out during dispatch.
+  dispatched: 0,
+  // True while the requests are being handed over; see holdScreen below.
   closeLocked: false,
 });
 
@@ -127,6 +132,15 @@ const exclusionNotice = computed(() => {
   return `${excluded} of the ${targets.value.length} selected workloads ${verb} already being deleted and ${verb} not part of this request.`;
 });
 
+// How far the handing over has got, for the bar and the "3 of 8".
+const dispatchTotal = computed(() => requestTargets.value.length);
+const dispatchPercent = computed(() =>
+  dispatchTotal.value === 0
+    ? 100
+    : Math.round((state.dispatched / dispatchTotal.value) * 100),
+);
+const submitEstimateSeconds = computed(() => submitSeconds(dispatchTotal.value));
+
 const retryNotice = computed(() => {
   const retries = retryTargets.value.length;
   if (!retries) return '';
@@ -192,116 +206,174 @@ function reasonFrom(rejected: any): string | null {
   return extractErrorMessage(raw);
 }
 
-// Issues delete requests for the given infras (terminate|force), recording each for tracking.
-function fireDeletes(mciList: any[], option: string): string[] {
-  const uids: string[] = [];
-  for (const mci of mciList) {
-    const uid = mci?.uid as string;
-    const infraId = mci?.name as string;
-    // Without a uid there is nothing to track — a name is reused and cannot be the key.
-    if (!uid) continue;
+/**
+ * Issues one delete request and starts tracking it.
+ *
+ * Nothing is awaited here on purpose: the call answers only when the delete finishes, and the
+ * caller spaces the sends out rather than queueing behind each answer.
+ */
+function fireDelete(target: DeleteTarget, option: string): void {
+  // Already running: do not issue another request. The existing record is what is shown.
+  if (isDeleteInProgress(target.uid)) return;
 
-    // Already running: do not issue another request, just track the existing record.
-    if (isDeleteInProgress(uid)) {
-      uids.push(uid);
-      continue;
-    }
-    const reqId = newReqId();
-    putDeleteRecord({
-      uid,
-      infraId,
-      nsId: props.nsId,
-      reqId,
-      option,
-      status: 'Handling',
+  const reqId = newReqId();
+  putDeleteRecord({
+    uid: target.uid,
+    infraId: target.name,
+    nsId: props.nsId,
+    reqId,
+    option,
+    status: 'Handling',
+  });
+  useDeleteMci({ nsId: props.nsId, infraId: target.name, option }, reqId)
+    .execute()
+    // A success keeps no record — the infra leaves the list, so there is nothing to show.
+    // Announce the success from here. The tracker cannot: clearing on success would take
+    // the record out of what it inspects, so nothing would ever report the completion.
+    .then(() => markDeleteSucceeded(target.uid))
+    .catch((rejected: any) => {
+      const reason = reasonFrom(rejected) ?? undefined;
+      const code = statusCodeOf(rejected);
+
+      // **A timeout is not a failed delete.** This call runs for minutes and the proxy
+      // gives up at 504 long before the server does; the delete carries on and usually
+      // succeeds. Marking Error here told the user it had failed while the infra was in
+      // fact being removed — observed on the dev server, where the infra was gone and the
+      // screen said it had failed. Leave it in Handling and let the tracker conclude.
+      if (code === undefined || code === 504 || code >= 500) {
+        noteDeleteRequestError(target.uid, reason);
+        return;
+      }
+
+      // Anything else the server rejected outright (400, 401, 403, …) means the delete
+      // never started. Leaving it in Handling would be the worst outcome: that status is
+      // what blocks a second attempt, so the workload could never be deleted again even
+      // though nothing had happened to it. Close it out as a failure, with the reason.
+      markDeleteFailed(target.uid, reason);
     });
-    useDeleteMci({ nsId: props.nsId, infraId, option }, reqId)
-      .execute()
-      // A success keeps no record — the infra leaves the list, so there is nothing to show.
-      // Announce the success from here. The tracker cannot: clearing on success would take
-      // the record out of what it inspects, so nothing would ever report the completion.
-      .then(() => markDeleteSucceeded(uid))
-      .catch((rejected: any) => {
-        const reason = reasonFrom(rejected) ?? undefined;
-        const code = statusCodeOf(rejected);
-
-        // **A timeout is not a failed delete.** This call runs for minutes and the proxy
-        // gives up at 504 long before the server does; the delete carries on and usually
-        // succeeds. Marking Error here told the user it had failed while the infra was in
-        // fact being removed — observed on the dev server, where the infra was gone and the
-        // screen said it had failed. Leave it in Handling and let the tracker conclude.
-        if (code === undefined || code === 504 || code >= 500) {
-          noteDeleteRequestError(uid, reason);
-          return;
-        }
-
-        // Anything else the server rejected outright (400, 401, 403, …) means the delete
-        // never started. Leaving it in Handling would be the worst outcome: that status is
-        // what blocks a second attempt, so the workload could never be deleted again even
-        // though nothing had happened to it. Close it out as a failure, with the reason.
-        markDeleteFailed(uid, reason);
-      });
-    uids.push(uid);
-  }
-  return uids;
 }
 
 /**
- * Holds the dialog open for a moment after the requests go out.
+ * How far apart the requests go out, and how long to wait after the last one.
  *
- * The delete is a synchronous call that runs for minutes, so there is no reply to say the
- * request was accepted. What there is: cm-beetle writes the request down the instant it
- * arrives, before the handler runs. Once that has had time to happen the outcome can be
- * fetched by reqId from anywhere, so leaving is safe — but leaving *before* it means the
- * request may never have landed and nothing is left to look it up with.
+ * Deleting a workload begins, on the other side, with a lookup — and that lookup is capped at
+ * two a second. Sending everything at once put the third onward over the cap, and a lookup
+ * turned away is not retried: that delete ended there and came back as a failure. Deleting
+ * them one at a time always worked, which is the same thing said from the other end.
+ *
+ * So they are spaced out. 800ms leaves room under the cap for the list refresh, which draws
+ * from the same allowance while workloads are in transition — exactly when a delete is running.
+ *
+ * The settle at the end is for the last request to land. The request is written down the moment
+ * it arrives, and from then on its outcome can be fetched from anywhere; before that there is
+ * nothing to fetch it with.
  */
-const CLOSE_LOCK_MS = 5000;
-let closeLockTimer: ReturnType<typeof setTimeout> | undefined;
+const SEND_INTERVAL_MS = 800;
+const SETTLE_MS = 1500;
 
-function lockClose() {
+/** Above this many targets, say what the wait is for before sending anything. */
+const NOTICE_THRESHOLD = 5;
+
+/** Roughly how long the handing over will take, in whole seconds. */
+function submitSeconds(count: number): number {
+  if (count <= 0) return 0;
+  return Math.max(1, Math.round(((count - 1) * SEND_INTERVAL_MS + SETTLE_MS) / 1000));
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Holds the screen while the requests are being handed over.
+ *
+ * Leaving in the middle of it would strand whatever had not been sent — the loop lives here, so
+ * it goes when the screen does. Once a request has landed it is written down and can be followed
+ * from anywhere, which is why the hold ends where it does rather than lasting the whole delete.
+ *
+ * Both ways out are covered: the router for anything inside the app (including the back button),
+ * and the browser's own prompt for a reload or a closed tab.
+ */
+let releaseRouterGuard: (() => void) | undefined;
+
+function warnBeforeUnload(event: BeforeUnloadEvent) {
+  event.preventDefault();
+  event.returnValue = '';
+}
+
+function holdScreen() {
   state.closeLocked = true;
-  if (closeLockTimer) clearTimeout(closeLockTimer);
-  closeLockTimer = setTimeout(() => {
-    state.closeLocked = false;
-    closeLockTimer = undefined;
-  }, CLOSE_LOCK_MS);
-}
-
-function unlockClose() {
-  if (closeLockTimer) {
-    clearTimeout(closeLockTimer);
-    closeLockTimer = undefined;
+  if (!releaseRouterGuard) {
+    releaseRouterGuard = McmpRouter.getRouter().beforeEach((_to, _from, next) => {
+      next(false);
+    });
   }
-  state.closeLocked = false;
+  window.addEventListener('beforeunload', warnBeforeUnload);
 }
 
-onBeforeUnmount(unlockClose);
+function releaseScreen() {
+  state.closeLocked = false;
+  releaseRouterGuard?.();
+  releaseRouterGuard = undefined;
+  window.removeEventListener('beforeunload', warnBeforeUnload);
+}
 
-// Runs the delete from confirm: issue the request and move to progress rather than closing.
-// Everything selected is passed on — fireDeletes skips the ones already running, so they are
-// tracked and shown without a second request going out for them.
+onBeforeUnmount(releaseScreen);
+
+/**
+ * Runs the delete from confirm.
+ *
+ * A large selection is told what the wait is for first — the handing over takes a second per
+ * workload, and that is worth knowing before it starts rather than while it is happening.
+ */
 function handleConfirm() {
   if (state.phase !== 'confirm') return;
+  if (requestTargets.value.length >= NOTICE_THRESHOLD) {
+    state.phase = 'notice';
+    return;
+  }
+  void startDispatch();
+}
+
+/**
+ * Hands the requests over, one at a time, and holds the screen until they are all in.
+ *
+ * The requests are not awaited — a delete answers only when it finishes, minutes later, and
+ * waiting for that would stall the ones behind it. What is spaced out is the *sending*.
+ */
+async function startDispatch() {
   const option = state.deleteMethod === 'force' ? 'force' : 'terminate';
+  const sending = requestTargets.value;
+
   state.alreadyInProgress = inflightTargets.value.length > 0;
-  trackedIds.value = fireDeletes(targets.value, option);
-  state.phase = 'progress';
-  lockClose();
+  state.dispatched = 0;
+  state.phase = 'dispatch';
+  trackedIds.value = targets.value.map(t => t.uid);
+  holdScreen();
   emit('deleted'); // refresh so the list brings up the Delete Status column at once
+
+  for (const [index, target] of sending.entries()) {
+    if (index > 0) await sleep(SEND_INTERVAL_MS);
+    fireDelete(target, option);
+    state.dispatched = index + 1;
+  }
+
+  // Let the last one land before anyone can walk away from it.
+  await sleep(SETTLE_MS);
+  releaseScreen();
+  state.phase = 'progress';
 }
 
 // [Force Delete] in the error step: retry the failed targets with force and move to progress.
 // Force leaves the CSP resources and removes only the internal records, as the banner says.
-// The records are in Error rather than in flight, so fireDeletes issues fresh reqIds.
+// The records are in Error rather than in flight, so fresh reqIds go out for them.
 function handleForceDelete() {
-  const forceTargets = erroredRecords.value.map(r => ({
+  const forceTargets: DeleteTarget[] = erroredRecords.value.map(r => ({
     uid: r.uid,
     name: r.infraId,
+    kind: 'retry' as const,
   }));
-  trackedIds.value = fireDeletes(forceTargets, 'force');
-  state.phase = 'progress';
-  lockClose();
-  emit('deleted');
+  targets.value = forceTargets;
+  state.deleteMethod = 'force';
+  void startDispatch();
 }
 
 // [Retry] in the error step goes back to confirm. A normal delete sometimes succeeds on a
@@ -333,7 +405,8 @@ function resetState() {
   state.confirmKeyword = '';
   state.phase = 'confirm';
   state.alreadyInProgress = false;
-  unlockClose();
+  state.dispatched = 0;
+  releaseScreen();
   trackedIds.value = [];
   targets.value = [];
 }
@@ -399,6 +472,7 @@ watch(
     header-title="Delete Workloads"
     size="sm"
     hide-footer
+    :hide-header-close-button="state.closeLocked"
     @close="handleClose"
     @update:visible="handleVisibleUpdate"
   >
@@ -429,6 +503,62 @@ watch(
           Force delete removes only the internal records and leaves the CSP
           resources in place. Any resources left behind keep billing and must be
           removed by hand.
+        </p>
+      </div>
+
+      <!--
+        notice step — a large selection, before anything is sent.
+
+        Sentences are left to wrap on their own. The dialog has a fixed width, so breaking the
+        lines here would only fight it and leave sentences cut at odd places on other widths.
+        Each paragraph carries one idea and that is where the breaks are.
+      -->
+      <div
+        v-else-if="state.phase === 'notice'"
+        class="delete-modal-content"
+        data-testid="mci-delete-notice"
+      >
+        <p class="notice-lead">
+          <b>{{ dispatchTotal }} workloads selected.</b>
+        </p>
+        <p class="notice-body">
+          Requests are submitted one at a time — about one per second — because only so
+          many can be handled at once. Submitting all {{ dispatchTotal }} takes about
+          <b>{{ submitEstimateSeconds }} seconds</b>, and you cannot leave this screen
+          until that is done.
+        </p>
+        <p class="notice-body">
+          That is the submitting, not the deleting. Once the requests are in, the
+          deletions continue on their own and take considerably longer. You can leave
+          this screen at that point and follow them in the <b>Delete Status</b> column
+          of the list.
+        </p>
+        <p class="notice-body">
+          Selecting fewer at a time gets the submitting done sooner.
+        </p>
+      </div>
+
+      <!--
+        dispatch step — the requests going out, one at a time. There is no button here: the
+        screen is held until the last one has landed, and saying so is the only thing to do.
+      -->
+      <div
+        v-else-if="state.phase === 'dispatch'"
+        class="delete-modal-content"
+        data-testid="mci-delete-dispatch"
+      >
+        <p class="description">
+          Submitting delete requests
+          <span class="dispatch-count" data-testid="mci-delete-dispatch-count"
+            >{{ state.dispatched }} of {{ dispatchTotal }}</span
+          >
+        </p>
+        <div class="dispatch-bar">
+          <div class="dispatch-bar-fill" :style="{ width: `${dispatchPercent}%` }" />
+        </div>
+        <p class="hint">
+          Please stay on this screen until this finishes. Each delete begins as its
+          request goes out and continues in the background afterwards.
         </p>
       </div>
 
@@ -473,15 +603,7 @@ watch(
             <span v-else class="progress-status done">Deleted</span>
           </div>
         </div>
-        <p
-          v-if="state.closeLocked"
-          class="hint"
-          data-testid="mci-delete-accepting"
-        >
-          Handing the request over. This takes a moment — once it is done you can
-          leave and the result will still find its way back.
-        </p>
-        <p v-else-if="anyHandling" class="hint">
+        <p v-if="anyHandling" class="hint">
           Closing this dialog does not stop the delete. You can follow it in the
           <b>Delete Status</b> column of the list.
         </p>
@@ -606,12 +728,30 @@ watch(
             Force Delete
           </p-button>
         </template>
+        <!-- notice: back out, or go ahead knowing what the wait is -->
+        <template v-if="state.phase === 'notice'">
+          <p-button
+            style-type="transparent"
+            data-testid="wl-delete-notice-cancel"
+            @click="handleClose"
+          >
+            Cancel
+          </p-button>
+          <p-button
+            style-type="negative-primary"
+            data-testid="wl-delete-notice-continue"
+            @click="startDispatch"
+          >
+            Continue
+          </p-button>
+        </template>
+        <!-- dispatch: nothing to press. The screen is held until the last request lands -->
+        <template v-else-if="state.phase === 'dispatch'" />
         <!-- progress: close only; the delete carries on and the list keeps showing it -->
         <template v-else-if="state.phase === 'progress'">
           <p-button
             style-type="transparent"
             data-testid="wl-delete-close"
-            :disabled="state.closeLocked"
             @click="handleClose"
           >
             Close
@@ -729,6 +869,36 @@ watch(
     font-size: 12px;
     color: #6b7280;
     line-height: 1.5;
+  }
+
+  .notice-lead {
+    font-size: 14px;
+    margin-bottom: 14px;
+  }
+  .notice-body {
+    font-size: 14px;
+    line-height: 1.6;
+  }
+  .notice-body + .notice-body {
+    margin-top: 14px;
+  }
+
+  .dispatch-count {
+    margin-left: 8px;
+    font-family: monospace;
+    color: #6b7280;
+  }
+  .dispatch-bar {
+    margin-top: 12px;
+    height: 6px;
+    border-radius: 3px;
+    background-color: #e5e7eb;
+    overflow: hidden;
+  }
+  .dispatch-bar-fill {
+    height: 100%;
+    background-color: #6b7280;
+    transition: width 200ms linear;
   }
 
   .warning-note {


### PR DESCRIPTION
## Why

Deleting several workloads at once left some of them failed. Deleting them one at a time always worked, which is the same thing said from the other end.

A delete begins, on the other side, with a lookup of the workload — and that lookup is capped at two a second. Sending everything at once put the third onward over the cap, and a lookup turned away is not retried: **that delete ended right there and came back as a failure.** Nothing about the delete itself was capped, which is why it took a while to find.

## What

Requests now go out **one at a time, 800ms apart**. That leaves room under the cap for the list refresh, which draws from the same allowance while workloads are in transition — exactly when a delete is running.

That spacing is time the user has to be told about, and **it is not the time the delete takes**. The dialog separates the two.

| | |
|---|---|
| **Submitting** | the requests going out, with a bar. The screen is held here: leaving would strand whatever had not been sent, since the loop lives in the dialog. Once a request lands it is written down and can be followed from anywhere, which is where the hold ends |
| **Deleting** | as before. Free to close, free to leave, followed in the list |

<img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/pacing-submitting.png" width="470">

Both ways out are covered while submitting — the router for anything inside the app, including the back button, and the browser's own prompt for a reload or a closed tab. The dialog's own close is gone rather than present and inert.

## Saying it before it starts

Five or more targets get a word before anything is sent: how long the submitting will take, that it is the submitting and not the deleting, and that fewer at a time gets through it sooner. Cancel there sends nothing.

<img src="https://raw.githubusercontent.com/wiki/MZC-CSC/cm-butterfly/assets/workload-delete-ux/pacing-notice.png" width="470">

The seconds in that text come from the same constant the sending uses, so the two cannot drift apart.

## How it was checked

The previous build and this one were built as images and run side by side against the same backend, and the same end-to-end scenarios were run against both. Everything that passed before still passes, and two new scenarios covering this fail on the previous build — one for the notice and what cancelling does, one for the screen being held while submitting.

Type check, scenario generation and the image build all pass.