### PR TITLE
improve(workflow): map a target model into a task body by path instead of a hardcoded key list

### DIFF
--- a/front/src/features/workflow/workflowEditor/lib/mapModelToTaskBody.ts
+++ b/front/src/features/workflow/workflowEditor/lib/mapModelToTaskBody.ts
@@ -1,0 +1,187 @@
+/**
+ * Fills a task's request body from a model, matching by **path** rather than by name.
+ *
+ * ## Why by path
+ *
+ * A task component's body shape comes from the target system's swagger; a target model holds the
+ * values. The two use the same names for the same things, so most of the body can be filled by
+ * simply carrying values across. What cannot be done is matching on the *leaf name alone* — the
+ * same name means different things in different places:
+ *
+ *   targetSecurityGroupList   under a recommended infra  → the security groups to create
+ *   targetSecurityGroupList   under a recommendation set → recommendation entries wrapping them
+ *   targetSpecList            under a recommended infra  → the specs that were chosen
+ *   targetSpec                under a recommendation     → one server's recommended spec
+ *   specId                    under a node group         → the spec that node group will use
+ *
+ * Matching "spec" to "spec" would hand a candidate list to a field expecting the chosen ones. So a
+ * value is carried across only when **the whole path agrees**, and the shape agrees with it.
+ *
+ * ## Why not a list of keys
+ *
+ * The previous approach named every key in code. It worked, and it kept working — until the other
+ * side grew a field. Then nothing failed: the new field simply was not carried, and the workflow
+ * was built without it. Silence is the problem this replaces. Here, whatever the body asks for is
+ * looked up, and **whatever could not be filled is reported** rather than passed over.
+ */
+
+/** A JSON-schema-ish node as it arrives from the task component (`body_params`). */
+interface SchemaNode {
+  type?: string;
+  properties?: Record<string, SchemaNode>;
+  items?: SchemaNode;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+export interface MapResult {
+  /** The body to send, with everything that could be carried across. */
+  body: Record<string, any>;
+  /** Paths that were filled from the model. */
+  filled: string[];
+  /** Paths the body asks for that the model had nothing for. */
+  missing: string[];
+  /** Of those, the ones the body declares as required — worth telling the user about. */
+  missingRequired: string[];
+  /** Paths where both sides had a value but the shapes disagreed (array vs object vs plain). */
+  mismatched: string[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Whether a schema node and a value describe the same kind of thing. */
+function shapeAgrees(schema: SchemaNode, value: unknown): boolean {
+  const declared = schema?.type;
+  if (declared === 'array') return Array.isArray(value);
+  if (declared === 'object') return isPlainObject(value);
+  if (declared === undefined) {
+    // No declared type — infer from what the schema carries.
+    if (schema?.items) return Array.isArray(value);
+    if (schema?.properties) return isPlainObject(value);
+    return true;
+  }
+  // string / number / boolean / integer
+  return !Array.isArray(value) && !isPlainObject(value);
+}
+
+/**
+ * Walks the body's schema and carries values across from the model at the same path.
+ *
+ * A path that the model has is taken whole — no descending into it. Its inside is the other
+ * system's business, and rebuilding it here is how values get quietly dropped. Descending happens
+ * only where the model has nothing at that path but the body asks for something deeper.
+ */
+function walk(
+  schemaProps: Record<string, SchemaNode>,
+  requiredHere: string[],
+  source: unknown,
+  into: Record<string, any>,
+  prefix: string,
+  result: MapResult,
+): void {
+  for (const [key, schema] of Object.entries(schemaProps ?? {})) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const isRequired = requiredHere.includes(key);
+    const value = isPlainObject(source) ? source[key] : undefined;
+
+    if (value !== undefined && value !== null) {
+      if (shapeAgrees(schema, value)) {
+        into[key] = value;
+        result.filled.push(path);
+      } else {
+        result.mismatched.push(path);
+        if (isRequired) result.missingRequired.push(path);
+        else result.missing.push(path);
+      }
+      continue;
+    }
+
+    // Nothing at this path. If the body asks for something deeper, look there before giving up —
+    // a model may carry the pieces without carrying the container.
+    if (schema?.properties) {
+      const nested: Record<string, any> = {};
+      const before = result.filled.length;
+      walk(
+        schema.properties,
+        schema.required ?? [],
+        isPlainObject(source) ? source[key] : undefined,
+        nested,
+        path,
+        result,
+      );
+      if (result.filled.length > before) {
+        into[key] = nested;
+        continue;
+      }
+    }
+
+    result.missing.push(path);
+    if (isRequired) result.missingRequired.push(path);
+  }
+}
+
+/**
+ * Fills a body from a model.
+ *
+ * @param bodyParams the task component's `body_params` (properties + required)
+ * @param model      the model with the values, **already unwrapped** (see unwrapModel)
+ * @param skeleton   the body the component came with; kept as the starting point so anything the
+ *                   schema does not describe is not thrown away
+ */
+export function mapModelToTaskBody(
+  bodyParams: { properties?: Record<string, SchemaNode>; required?: string[] } | undefined,
+  model: unknown,
+  skeleton: Record<string, any> = {},
+): MapResult {
+  const result: MapResult = {
+    body: { ...skeleton },
+    filled: [],
+    missing: [],
+    missingRequired: [],
+    mismatched: [],
+  };
+
+  if (!bodyParams?.properties) {
+    // No schema to go by. Carrying values across blind would be guessing, so the body is left as
+    // it came and the caller is told nothing was filled.
+    return result;
+  }
+
+  walk(
+    bodyParams.properties,
+    bodyParams.required ?? [],
+    model,
+    result.body,
+    '',
+    result,
+  );
+  return result;
+}
+
+/**
+ * Takes the values out of the wrapper a target model keeps them in.
+ *
+ * A target model holds its values under `cloudInfraModel` (infra) or `targetSoftwareModel`
+ * (software), while the body asks for them at the top. The wrapper is the only difference, so
+ * removing it lines the two up.
+ *
+ * `targetSoftwareModel` is also a field *inside* the software body, so it is kept alongside the
+ * unwrapped values rather than replaced by them.
+ */
+export function unwrapModel(targetModel: any): Record<string, any> {
+  if (!isPlainObject(targetModel)) return {};
+
+  if (isPlainObject(targetModel.cloudInfraModel)) {
+    return { ...targetModel, ...targetModel.cloudInfraModel };
+  }
+  if (isPlainObject(targetModel.targetSoftwareModel)) {
+    return {
+      ...targetModel,
+      ...targetModel.targetSoftwareModel,
+      targetSoftwareModel: targetModel.targetSoftwareModel,
+    };
+  }
+  return { ...targetModel };
+}

--- a/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
+++ b/front/src/features/workflow/workflowEditor/ui/WorkflowEditor.vue
@@ -33,6 +33,10 @@ import {
 } from '@/features/sequential/designer/toolbox/model/api';
 import getRandomId from '@/shared/utils/uuid';
 import { parseRequestBody } from '@/shared/utils/stringToObject';
+import {
+  mapModelToTaskBody,
+  unwrapModel,
+} from '@/features/workflow/workflowEditor/lib/mapModelToTaskBody';
 import SequentialDesigner from '@/features/sequential/designer/ui/SequentialDesigner.vue';
 import { DEFAULT_NAMESPACE } from '@/shared/constants/namespace';
 import { normalizeTaskComponentList } from '@/entities/workflow/lib/schemaAdapter';
@@ -372,84 +376,128 @@ function mapTargetModelToTaskComponent(
 
   const parseString = parseRequestBody(taskComponent.data.options.request_body);
 
-  if (isInfraModel && targetModel?.cloudInfraModel?.targetInfra) {
-    // Handle infra model data - use targetInfra from cloudInfraModel
-    console.log(
-      'Processing infra model with targetInfra:',
-      targetModel.cloudInfraModel.targetInfra,
-    );
+  // ── Filling the body: matched by path, not by name ─────────────────────
+  //
+  // The body's shape comes from the other system's swagger; the model holds the values. Both use
+  // the same names for the same things, so the body is filled by looking up **the same path** in
+  // the model — not by matching leaf names, which collide (see mapModelToTaskBody).
+  //
+  // What this replaces is below, kept as a comment on purpose: it named every key in code, and a
+  // field the other side added was simply never carried — with nothing said about it.
+  const unwrapped = unwrapModel(targetModel);
+  const mapped = mapModelToTaskBody(
+    taskComponent?.data?.body_params,
+    unwrapped,
+    parseString ?? {},
+  );
+  Object.assign(parseString, mapped.body);
 
-    if (parseString) {
-      // Set the targetInfra data directly
-      parseString['targetInfra'] = targetModel.cloudInfraModel.targetInfra;
-
-      // Also set other related infra data if available
-      if (targetModel.cloudInfraModel.targetSecurityGroupList) {
-        parseString['targetSecurityGroupList'] =
-          targetModel.cloudInfraModel.targetSecurityGroupList;
-      }
-      if (targetModel.cloudInfraModel.targetSshKey) {
-        parseString['targetSshKey'] = targetModel.cloudInfraModel.targetSshKey;
-      }
-      if (targetModel.cloudInfraModel.targetVNet) {
-        parseString['targetVNet'] = targetModel.cloudInfraModel.targetVNet;
-      }
-      if (targetModel.cloudInfraModel.targetOsImageList) {
-        parseString['targetOsImageList'] =
-          targetModel.cloudInfraModel.targetOsImageList;
-      }
-      if (targetModel.cloudInfraModel.targetSpecList) {
-        parseString['targetSpecList'] =
-          targetModel.cloudInfraModel.targetSpecList;
-      }
-    }
-    console.log('Processed infra model data:', parseString);
-  } else if (isSoftwareModel && (targetModel as any)?.targetSoftwareModel) {
-    // Handle software model data - use targetSoftwareModel
-    const targetSoftwareModel = (targetModel as any).targetSoftwareModel;
-    console.log(
-      'Processing software model with targetSoftwareModel:',
-      targetSoftwareModel,
-    );
-
-    if (parseString) {
-      // Set the targetSoftwareModel data directly
-      parseString['targetSoftwareModel'] = targetSoftwareModel;
-
-      // Also set other related software data if available
-      if (targetSoftwareModel.softwareList) {
-        parseString['softwareList'] = targetSoftwareModel.softwareList;
-      }
-      if (targetSoftwareModel.targetSpecList) {
-        parseString['targetSpecList'] = targetSoftwareModel.targetSpecList;
-      }
-      if (targetSoftwareModel.targetOsImageList) {
-        parseString['targetOsImageList'] =
-          targetSoftwareModel.targetOsImageList;
-      }
-      if (targetSoftwareModel.targetSecurityGroupList) {
-        parseString['targetSecurityGroupList'] =
-          targetSoftwareModel.targetSecurityGroupList;
-      }
-      if (targetSoftwareModel.targetSshKey) {
-        parseString['targetSshKey'] = targetSoftwareModel.targetSshKey;
-      }
-      if (targetSoftwareModel.targetVNet) {
-        parseString['targetVNet'] = targetSoftwareModel.targetVNet;
-      }
-
-      // Set basic model information
-      parseString['softwareModel'] = {
-        id: targetModel.id,
-        name: targetModel.userModelName,
-        description: targetModel.description,
-        csp: targetModel.csp,
-        region: targetModel.region,
-        zone: targetModel.zone,
-      };
-    }
-    console.log('Processed software model data:', parseString);
+  // Software migration also names the model itself in the body; it is not part of the recommended
+  // infra shape, so it is set here rather than being looked up.
+  if (isSoftwareModel) {
+    parseString['softwareModel'] = {
+      id: targetModel.id,
+      name: targetModel.userModelName,
+      description: targetModel.description,
+      csp: targetModel.csp,
+      region: targetModel.region,
+      zone: targetModel.zone,
+    };
   }
+
+  // **Say what could not be carried.** A body that asks for something the model has nothing for is
+  // the failure this whole change exists to surface — before, it left no trace at all.
+  if (mapped.missingRequired.length > 0) {
+    showErrorMessage(
+      'Some required values could not be filled',
+      `The workflow asks for ${mapped.missingRequired.join(', ')}, and the selected target model has no value for them. Check the task before running it.`,
+    );
+  }
+  console.log('[task body] filled:', mapped.filled);
+  console.log('[task body] not filled:', mapped.missing);
+  if (mapped.mismatched.length > 0) {
+    console.warn('[task body] shape did not agree:', mapped.mismatched);
+  }
+
+  // ── What this replaced, kept so the change is legible: every key named in code ──
+  // if (isInfraModel && targetModel?.cloudInfraModel?.targetInfra) {
+  //   // Handle infra model data - use targetInfra from cloudInfraModel
+  //   console.log(
+  //     'Processing infra model with targetInfra:',
+  //     targetModel.cloudInfraModel.targetInfra,
+  //   );
+  //
+  //   if (parseString) {
+  //     // Set the targetInfra data directly
+  //     parseString['targetInfra'] = targetModel.cloudInfraModel.targetInfra;
+  //
+  //     // Also set other related infra data if available
+  //     if (targetModel.cloudInfraModel.targetSecurityGroupList) {
+  //       parseString['targetSecurityGroupList'] =
+  //         targetModel.cloudInfraModel.targetSecurityGroupList;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetSshKey) {
+  //       parseString['targetSshKey'] = targetModel.cloudInfraModel.targetSshKey;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetVNet) {
+  //       parseString['targetVNet'] = targetModel.cloudInfraModel.targetVNet;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetOsImageList) {
+  //       parseString['targetOsImageList'] =
+  //         targetModel.cloudInfraModel.targetOsImageList;
+  //     }
+  //     if (targetModel.cloudInfraModel.targetSpecList) {
+  //       parseString['targetSpecList'] =
+  //         targetModel.cloudInfraModel.targetSpecList;
+  //     }
+  //   }
+  //   console.log('Processed infra model data:', parseString);
+  // } else if (isSoftwareModel && (targetModel as any)?.targetSoftwareModel) {
+  //   // Handle software model data - use targetSoftwareModel
+  //   const targetSoftwareModel = (targetModel as any).targetSoftwareModel;
+  //   console.log(
+  //     'Processing software model with targetSoftwareModel:',
+  //     targetSoftwareModel,
+  //   );
+  //
+  //   if (parseString) {
+  //     // Set the targetSoftwareModel data directly
+  //     parseString['targetSoftwareModel'] = targetSoftwareModel;
+  //
+  //     // Also set other related software data if available
+  //     if (targetSoftwareModel.softwareList) {
+  //       parseString['softwareList'] = targetSoftwareModel.softwareList;
+  //     }
+  //     if (targetSoftwareModel.targetSpecList) {
+  //       parseString['targetSpecList'] = targetSoftwareModel.targetSpecList;
+  //     }
+  //     if (targetSoftwareModel.targetOsImageList) {
+  //       parseString['targetOsImageList'] =
+  //         targetSoftwareModel.targetOsImageList;
+  //     }
+  //     if (targetSoftwareModel.targetSecurityGroupList) {
+  //       parseString['targetSecurityGroupList'] =
+  //         targetSoftwareModel.targetSecurityGroupList;
+  //     }
+  //     if (targetSoftwareModel.targetSshKey) {
+  //       parseString['targetSshKey'] = targetSoftwareModel.targetSshKey;
+  //     }
+  //     if (targetSoftwareModel.targetVNet) {
+  //       parseString['targetVNet'] = targetSoftwareModel.targetVNet;
+  //     }
+  //
+  //     // Set basic model information
+  //     parseString['softwareModel'] = {
+  //       id: targetModel.id,
+  //       name: targetModel.userModelName,
+  //       description: targetModel.description,
+  //       csp: targetModel.csp,
+  //       region: targetModel.region,
+  //       zone: targetModel.zone,
+  //     };
+  //   }
+  //   console.log('Processed software model data:', parseString);
+  // }
 
   // Set path_params and query_params from task component with nsId default value.
   // ★ A schema property's description is *explanatory text (a placeholder)*, not a value. Leave the


### PR DESCRIPTION
## What changed

When a workflow is created from a target model, the model's values are copied into the task's request body. Until now that copying **named every field in code**, once for the infra model and again for the software model.

**Infra model** — six fields, each copied with its own `if`:

```ts
if (isInfraModel && targetModel?.cloudInfraModel?.targetInfra) {
  if (parseString) {
    parseString['targetInfra'] = targetModel.cloudInfraModel.targetInfra;

    if (targetModel.cloudInfraModel.targetSecurityGroupList) {
      parseString['targetSecurityGroupList'] =
        targetModel.cloudInfraModel.targetSecurityGroupList;
    }
    if (targetModel.cloudInfraModel.targetSshKey) {
      parseString['targetSshKey'] = targetModel.cloudInfraModel.targetSshKey;
    }
    if (targetModel.cloudInfraModel.targetVNet) {
      parseString['targetVNet'] = targetModel.cloudInfraModel.targetVNet;
    }
    if (targetModel.cloudInfraModel.targetOsImageList) {
      parseString['targetOsImageList'] =
        targetModel.cloudInfraModel.targetOsImageList;
    }
    if (targetModel.cloudInfraModel.targetSpecList) {
      parseString['targetSpecList'] =
        targetModel.cloudInfraModel.targetSpecList;
    }
  }
}
```

**Software model** — seven more of the same, plus a hand-assembled `softwareModel`:

```ts
} else if (isSoftwareModel && targetModel?.targetSoftwareModel) {
  const targetSoftwareModel = targetModel.targetSoftwareModel;

  if (parseString) {
    parseString['targetSoftwareModel'] = targetSoftwareModel;

    if (targetSoftwareModel.softwareList) {
      parseString['softwareList'] = targetSoftwareModel.softwareList;
    }
    if (targetSoftwareModel.targetSpecList) {
      parseString['targetSpecList'] = targetSoftwareModel.targetSpecList;
    }
    if (targetSoftwareModel.targetOsImageList) {
      parseString['targetOsImageList'] = targetSoftwareModel.targetOsImageList;
    }
    if (targetSoftwareModel.targetSecurityGroupList) {
      parseString['targetSecurityGroupList'] =
        targetSoftwareModel.targetSecurityGroupList;
    }
    if (targetSoftwareModel.targetSshKey) {
      parseString['targetSshKey'] = targetSoftwareModel.targetSshKey;
    }
    if (targetSoftwareModel.targetVNet) {
      parseString['targetVNet'] = targetSoftwareModel.targetVNet;
    }

    parseString['softwareModel'] = {
      id: targetModel.id,
      name: targetModel.userModelName,
      description: targetModel.description,
      csp: targetModel.csp,
      region: targetModel.region,
      zone: targetModel.zone,
    };
  }
}
```

That whole listing is replaced by **mapping from the target model by path**. The task component already carries the body's schema, so the schema is walked and each field is filled from **the same path in the model**:

```ts
const unwrapped = unwrapModel(targetModel);
const mapped = mapModelToTaskBody(
  taskComponent?.data?.body_params,
  unwrapped,
  parseString ?? {},
);
Object.assign(parseString, mapped.body);
```

The per-model branching is gone too — the only real difference between the two was the wrapper the values sit in (`cloudInfraModel` / `targetSoftwareModel`), and `unwrapModel()` now handles that in one place.

## Why

**Nothing was broken.** The listed fields are enough for infra and software migration to succeed today. The reason to change it is what comes next:

- when the API's request body grows a field, **someone has to come back and extend the list**
- if they don't, the field is simply **not carried, with no error** — the workflow is built without it
- every new kind of migration adds another branch

One of the fields not in the list is `targetNlbList`. Once a model carries it, this way of mapping picks it up on its own. **That alone does not make NLB work** — an NLB is created by a separate call after the infra exists, so it needs values passed between tasks, which is a different problem.

## Why by path, not by name

The same name means different things in different places:

| Name | Where | What it is |
|---|---|---|
| `targetSecurityGroupList` | under a recommended infra | the security groups **to create** |
| `targetSecurityGroupList` | under a recommendation set | **recommendation entries** wrapping them |
| `targetSpecList` | under a recommended infra | the specs that were **chosen** |
| `targetSpec` | under a recommendation | one server's **candidate** spec |

Matching "spec" to "spec" would hand a candidate list to a field expecting the chosen ones. A value is carried across only when **the whole path agrees** and the shape (object / array / scalar) agrees with it.

## Also

- **What could not be filled is reported.** If the body declares a field required and the model has nothing at that path, the field is named to the user — so a newly required field on the other side does not pass silently.
- **The previous listing is kept as a comment** directly below the new call, so what used to be copied by hand and what is now derived can be read side by side.

## Verification

The base (current `develop`) and this branch were each built into an image, run on the same network, and the **same functional e2e suite was run against both**.

| | Result |
|---|---|
| base | 36 passed / 21 failed |
| this branch | 41 passed / 16 failed |
| **failing only on this branch** | **none** |

Counts were not used as the verdict — runs vary by 3–5 scenarios because scenarios needing live resources time out under load. The verdict is the **set difference of failing scenario names**, sorted; the 16 common failures are identical on both sides.

`vue-tsc --noEmit` and the image build both pass.

## Not verified

- Running an actual migration with the produced body — that needs live resources.
- Whether NLB values ride along: the recommendation the console calls does not produce them, so there is nothing in the model to carry. Mapping only moves what exists.
