### PR TITLE
improve(workflow): let saving be what tells the run status screen to read again

### DIFF
--- a/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
+++ b/front/src/features/sequential/designer/editor/ui/BashTaskEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="custom-task-editor">
+  <div class="custom-task-editor" data-testid="wf-task-editor">
     <div class="section-header"><h4>Bash Task</h4></div>
 
     <div class="field">
@@ -8,6 +8,7 @@
         class="text-input"
         type="text"
         :value="name"
+        data-testid="wf-task-name"
         placeholder="Enter task name"
         @input="onName"
       />
@@ -20,6 +21,7 @@
       <textarea
         class="text-area"
         rows="6"
+        data-testid="wf-task-spec-bash_command"
         :value="model.bash_command"
         placeholder="e.g. echo 'hello world'"
         @input="onCommand"

--- a/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
+++ b/front/src/pages/workflowManagement/workflows/ui/WorkflowsPage.vue
@@ -73,9 +73,24 @@ function handleEditJson(workflowId: string) {
 function handleSavedWorkflow(workflowId: string) {
   if (workflowId) selectedWorkflowId.value = workflowId;
   mainTabState.activeTab = 'runViewer';
+  markDefinitionSaved();
+}
+
+/**
+ * Tell the run status screen that the definition it is showing is no longer the current one.
+ *
+ * ★ The id is not enough to notice a save. Clone & Edit selects the clone up front, so the id is
+ *   already the clone's while it is being edited and does not move when it is saved — the screen
+ *   then keeps the definition it read before the edit and shows the old values under the words
+ *   "Values from the current definition". Saying it plainly is what this does.
+ */
+function markDefinitionSaved() {
+  runViewerReloadToken.value += 1;
 }
 
 const selectedWorkflowId = ref<string>('');
+/** Goes up by one on every save — the run status screen reads it as "read the definition again". */
+const runViewerReloadToken = ref<number>(0);
 
 /**
  * When arriving after creating a workflow on another screen (the target model).
@@ -209,6 +224,8 @@ async function handleUpdateWorkflow(updatedData: object) {
     // This used to throw and fall into the catch, which then showed a hardcoded, unrelated message.
     if (data.responseData?.data?.task_groups != null) {
       modalState.addWorkflow.trigger = true;
+      // Same event: saving from the JSON editor dates the definition on screen just as much.
+      markDefinitionSaved();
       showSuccessMessage('Success', 'Workflow data updated successfully.');
     } else {
       modalState.addWorkflow.trigger = true;
@@ -273,6 +290,7 @@ async function handleUpdateWorkflow(updatedData: object) {
             </div>
             <workflow-run-viewer
               :workflow-id="selectedWorkflowId"
+              :reload-token="runViewerReloadToken"
               @edit-json="handleEditJson"
               @view-json="handleEditJson"
               @edit-clone="handleEditClone"

--- a/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
+++ b/front/src/widgets/workflow/workflows/workflowRunViewer/ui/WorkflowRunViewer.vue
@@ -23,6 +23,17 @@ interface Props {
   workflowId: string | null;
   /** If empty, open the most recent run */
   runId?: string | null;
+  /**
+   * Bumped by the page whenever the definition is saved.
+   *
+   * ★ Reloading used to hang on the id changing, and that is not enough. Editing a clone sets the
+   *   id to the clone *before* the editor opens, so by the time it is saved the id is already what
+   *   it will be — nothing changes, nothing reloads, and the panel keeps showing the definition it
+   *   read before the edit. It says "Values from the current definition" while showing the values
+   *   the clone was made from; the saved definition and the machine that gets built use the new
+   *   ones. Saving is its own event, so it gets its own trigger.
+   */
+  reloadToken?: number;
 }
 
 const props = defineProps<Props>();
@@ -443,7 +454,7 @@ function formatDuration(seconds?: number): string {
 }
 
 watch(
-  () => [props.workflowId, props.runId],
+  () => [props.workflowId, props.runId, props.reloadToken],
   async () => {
     if (props.workflowId) await open(props.workflowId, props.runId);
   },


### PR DESCRIPTION
## The problem

The run status screen re-read the workflow definition only when the workflow id changed. Editing a copy sets the id to the copy before the editor opens, so by the time it is saved the id is already what it will be and nothing prompts a re-read.

It still showed the right values, because the editor happens to change the same object the screen is holding. Correctness rested on two parts sharing an object rather than on anything said out loud.

Where that sharing did not hold, the screen kept the values the copy was made from while the saved definition and the machine that got built used the new ones. A deployed build showed exactly that: port 5555 on screen, 6666 in the stored definition and in the security group of the machine it created.

## The change

Saving is its own event, so it gets its own trigger. The page raises a token on every save — from the graphic editor and from the JSON editor alike — and the run status screen watches that token alongside the workflow and run ids.

The bash task panel also gets a test identifier. Only the generic editor carried one, so a test could not find the panel when the task was of another type.

## Verified

On the current code the symptom does not reproduce. Three routes were measured before the change and all showed the saved value: a bash task's command, a shallow field, and a deep array field with its folded rows opened. In each, the definition was not re-read after saving; the value was right for the reason above.

## No regression test

A case that fails before the change cannot be written while the symptom does not reproduce, and a test that only ever passes guards nothing. The tooling is in place; the case gets added if the symptom becomes reachable again.